### PR TITLE
[버그] 원서 상세 조회에 주민등록번호 안옴

### DIFF
--- a/src/main/java/com/bamdoliro/maru/presentation/form/dto/response/ApplicantResponse.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/form/dto/response/ApplicantResponse.java
@@ -5,8 +5,6 @@ import com.bamdoliro.maru.domain.form.domain.value.Applicant;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.time.LocalDate;
-
 @Getter
 @AllArgsConstructor
 public class ApplicantResponse {
@@ -14,14 +12,14 @@ public class ApplicantResponse {
     private String identificationPictureUri;
     private String name;
     private String phoneNumber;
-    private LocalDate birthday;
+    private String registrationNumber;
     private Gender gender;
 
     public ApplicantResponse(Applicant applicant, String identificationPictureUri) {
         this.identificationPictureUri = identificationPictureUri;
         this.name = applicant.getName();
         this.phoneNumber = applicant.getPhoneNumber().toString();
-        this.birthday = applicant.getBirthday();
+        this.registrationNumber = applicant.getRegistrationNumber();
         this.gender = applicant.getGender();
     }
 }

--- a/src/test/java/com/bamdoliro/maru/shared/fixture/FormFixture.java
+++ b/src/test/java/com/bamdoliro/maru/shared/fixture/FormFixture.java
@@ -504,7 +504,7 @@ public class FormFixture {
                         "https://maru.com/photo.png",
                         "김밤돌",
                         "01012345678",
-                        LocalDate.of(2005, 4, 15),
+                        "080409-3111111",
                         Gender.FEMALE
                 ),
                 new ParentResponse(


### PR DESCRIPTION
## 🎫 관련 이슈

close #9 

<br>

## 📄 개요

> 디자인에 맞게 생년월일 대신 주민등록번호를 반환하도록 변경했습니다.

<br>

## 🔨 작업 내용

- 생년월일 대신 주민등록번호를 반환하도록 변경했습니다.


<br>

## 🏁 확인 사항
- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
