### PR TITLE
[버그] 전형 별 검색 안됨

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/form/QueryAllFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/QueryAllFormUseCase.java
@@ -19,9 +19,9 @@ public class QueryAllFormUseCase {
 
     private final FormRepository formRepository;
 
-    public List<FormSimpleResponse> execute(FormStatus status, FormType.Category category, String sort) {
+    public List<FormSimpleResponse> execute(FormStatus status, FormType type, String sort) {
         List<Form> formList = new java.util.ArrayList<>(formRepository.findByStatus(status).stream()
-                .filter(form -> Objects.isNull(category) || form.getType().categoryEquals(category))
+                .filter(form -> Objects.isNull(type) || form.getType().equals(type))
                 .toList());
 
         if (sort != null) {

--- a/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
@@ -206,7 +206,7 @@ public class FormController {
     public ListCommonResponse<FormSimpleResponse> getFormList(
             @AuthenticationPrincipal(authority = Authority.ADMIN) User user,
             @RequestParam(name = "status", required = false) FormStatus status,
-            @RequestParam(name = "type", required = false) FormType.Category type,
+            @RequestParam(name = "type", required = false) FormType type,
             @RequestParam(name = "sort", required = false) String sort
     ) {
         return ListCommonResponse.ok(

--- a/src/test/java/com/bamdoliro/maru/application/form/QueryAllFormUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/QueryAllFormUseCaseTest.java
@@ -71,7 +71,7 @@ class QueryAllFormUseCaseTest {
         List<FormSimpleResponse> returnedFormList = queryAllFormUseCase.execute(null, FormType.NATIONAL_VETERANS, null);
 
         // then
-        assertEquals(2, returnedFormList.size());
+        assertEquals(1, returnedFormList.size());
 
         verify(formRepository, times(1)).findByStatus(null);
     }

--- a/src/test/java/com/bamdoliro/maru/application/form/QueryAllFormUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/QueryAllFormUseCaseTest.java
@@ -68,7 +68,7 @@ class QueryAllFormUseCaseTest {
         given(formRepository.findByStatus(null)).willReturn(formList);
 
         // when
-        List<FormSimpleResponse> returnedFormList = queryAllFormUseCase.execute(null, FormType.Category.SPECIAL, null);
+        List<FormSimpleResponse> returnedFormList = queryAllFormUseCase.execute(null, FormType.NATIONAL_VETERANS, null);
 
         // then
         assertEquals(2, returnedFormList.size());
@@ -91,7 +91,7 @@ class QueryAllFormUseCaseTest {
         given(formRepository.findByStatus(null)).willReturn(formList);
 
         // when
-        List<FormSimpleResponse> returnedFormList = queryAllFormUseCase.execute(null, FormType.Category.SOCIETY_DIVERSITY, null);
+        List<FormSimpleResponse> returnedFormList = queryAllFormUseCase.execute(null, FormType.MULTI_CHILDREN, null);
 
         // then
         assertEquals(1, returnedFormList.size());
@@ -188,7 +188,7 @@ class QueryAllFormUseCaseTest {
         given(formRepository.findByStatus(null)).willReturn(formList);
 
         // when
-        List<FormSimpleResponse> returnedFormList = queryAllFormUseCase.execute(null, FormType.Category.SOCIETY_DIVERSITY, "form-id");
+        List<FormSimpleResponse> returnedFormList = queryAllFormUseCase.execute(null, FormType.MULTI_CHILDREN, "form-id");
 
         // then
         assertEquals(1, returnedFormList.size());

--- a/src/test/java/com/bamdoliro/maru/presentation/form/FormControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/form/FormControllerTest.java
@@ -1682,11 +1682,11 @@ class FormControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        given(queryAllFormUseCase.execute(FormStatus.SUBMITTED, FormType.Category.REGULAR, null)).willReturn(responseList);
+        given(queryAllFormUseCase.execute(FormStatus.SUBMITTED, FormType.REGULAR, null)).willReturn(responseList);
 
         mockMvc.perform(get("/forms")
                         .param("status", FormStatus.SUBMITTED.name())
-                        .param("type", FormType.Category.REGULAR.name())
+                        .param("type", FormType.REGULAR.name())
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                 )
@@ -1711,7 +1711,7 @@ class FormControllerTest extends RestDocsTestSupport {
                         )
                 ));
 
-        verify(queryAllFormUseCase, times(1)).execute(FormStatus.SUBMITTED, FormType.Category.REGULAR, null);
+        verify(queryAllFormUseCase, times(1)).execute(FormStatus.SUBMITTED, FormType.REGULAR, null);
     }
 
     @Test


### PR DESCRIPTION
## 🎫 관련 이슈

close #26

<br>

## 📄 개요

> 전형 별 검색이 카테고리가 아닌 전형 명으로 수정했다.

<br>

## 🔨 작업 내용

- FormController에 매개변수
- QueryAllFormUseCase 로직 수정
- 테스트 코드 수정


<br>

## 🏁 확인 사항

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말

