### PR TITLE
[버그] 휴대폰 인증 시 전송되는 메세지의 학교명 변경

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/user/SendVerificationUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/user/SendVerificationUseCase.java
@@ -23,7 +23,7 @@ public class SendVerificationUseCase {
         if (request.getType() == VerificationType.SIGNUP) {
             SignUpVerification signUpVerification = new SignUpVerification(request.getPhoneNumber());
             String text = String.format(
-                    "[부산소프트웨어마이스터고] 회원가입 인증번호는 [%s]입니다.",
+                    "[해운대고등학교] 회원가입 인증번호는 [%s]입니다.",
                     signUpVerification.getCode()
             );
 
@@ -36,7 +36,7 @@ public class SendVerificationUseCase {
         } else {
             UpdatePasswordVerification updatePasswordVerification = new UpdatePasswordVerification(request.getPhoneNumber());
             String text = String.format(
-                    "[부산소프트웨어마이스터고] 비밀번호 변경 인증번호는 [%s]입니다.",
+                    "[해운대고등학교] 비밀번호 변경 인증번호는 [%s]입니다.",
                     updatePasswordVerification.getCode()
             );
 


### PR DESCRIPTION
메세지에서 명시돼있는 학교를 부소마고에서 해운대고로 수정했습니다.

## 🎫 관련 이슈

close #30

<br>

## 📄 개요

> 메세지 인증이 전송될 때 표시된 부소마고를 해운대고등학교로 수정했습니다.

<br>

## 🔨 작업 내용

- SendVerificationUseCase에서 학교명을 해운대고등학교로 수정했습니다.


<br>

## 🏁 확인 사항

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말

