### PR TITLE
[버그] 엑셀 전체 내보내기 에러 수정

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/form/ExportResultUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/ExportResultUseCase.java
@@ -42,6 +42,8 @@ public class ExportResultUseCase {
                 form -> form.getGrade().getSubjectList().getSubjectMap().getSubjectListOf(2, 2).totalScore(),
                 form -> form.getGrade().getSubjectList().getSubjectMap().getSubjectListOf(3, 1).size(),
                 form -> form.getGrade().getSubjectList().getSubjectMap().getSubjectListOf(3, 1).totalScore(),
+                form -> form.getGrade().getSubjectList().getSubjectMap().getSubjectListOf(3, 2).size(),
+                form -> form.getGrade().getSubjectList().getSubjectMap().getSubjectListOf(3, 2).totalScore(),
                 form -> MathUtil.roundTo(form.getScore().getSubjectGradeScore(), 3),
                 form -> form.getScore().getAttendanceScore(),
                 form -> form.getScore().getSelfDirectedScore(),


### PR DESCRIPTION
## 🎫 관련 이슈

close #10

<br>

## 📄 개요

> 누락된 3학년 2학기 전체 내보내기 컬럼을 추가헀습니다.

<br>

## 🔨 작업 내용

- ExportResultUseCase에 3학년 2학기 컬럼을 추가했습니다.


<br>

## 🏁 확인 사항

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말

