### PR TITLE
[버그] 반려 원서 제출 수정

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/form/UpdateFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/UpdateFormUseCase.java
@@ -18,8 +18,8 @@ public class UpdateFormUseCase {
 
     @ValidateApplicationFormPeriod
     @Transactional
-    public void execute(User user, Long id, UpdateFormRequest request) {
-        Form form = formFacade.getForm(id);
+    public void execute(User user, UpdateFormRequest request) {
+        Form form = formFacade.getForm(user);
         form.isApplicant(user);
         validateFormStatus(form);
 

--- a/src/main/java/com/bamdoliro/maru/domain/form/domain/Form.java
+++ b/src/main/java/com/bamdoliro/maru/domain/form/domain/Form.java
@@ -227,7 +227,7 @@ public class Form extends BaseTimeEntity {
         this.document = document;
         this.type = type;
         this.originalType = type;
-        this.status = FormStatus.FINAL_SUBMITTED;
+        this.status = FormStatus.SUBMITTED;
     }
 
     public void assignExaminationNumber(Long examinationNumber) {

--- a/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/form/FormController.java
@@ -165,13 +165,12 @@ public class FormController {
     }
 
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    @PutMapping("/{form-id}")
+    @PutMapping()
     public void updateForm(
             @AuthenticationPrincipal(authority = Authority.USER) User user,
-            @PathVariable(name = "form-id") Long formId,
             @RequestBody @Valid UpdateFormRequest request
     ) {
-        updateFormUseCase.execute(user, formId, request);
+        updateFormUseCase.execute(user, request);
     }
 
     @PostMapping( "/identification-picture")

--- a/src/test/java/com/bamdoliro/maru/application/form/UpdateFormUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/UpdateFormUseCaseTest.java
@@ -39,29 +39,28 @@ class UpdateFormUseCaseTest {
         form.reject();
         User user = form.getUser();
 
-        given(formFacade.getForm(form.getId())).willReturn(form);
+        given(formFacade.getForm(user)).willReturn(form);
 
         // when
-        updateFormUseCase.execute(user, form.getId(), FormFixture.createUpdateFormRequest(FormType.NATIONAL_VETERANS));
+        updateFormUseCase.execute(user, FormFixture.createUpdateFormRequest(FormType.NATIONAL_VETERANS));
 
         // then
-        verify(formFacade, times(1)).getForm(form.getId());
+        verify(formFacade, times(1)).getForm(user);
         assertEquals(FormType.NATIONAL_VETERANS, form.getType());
     }
 
     @Test
     void 원서를_수정할_때_원서가_없으면_에러가_발생한다() {
         // given
-        Long formId = 1L;
         User user = UserFixture.createUser();
 
-        willThrow(new FormNotFoundException()).given(formFacade).getForm(formId);
+        willThrow(new FormNotFoundException()).given(formFacade).getForm(user);
 
         // when and then
         assertThrows(FormNotFoundException.class, () ->
-                updateFormUseCase.execute(user, formId, FormFixture.createUpdateFormRequest(FormType.NATIONAL_VETERANS)));
+                updateFormUseCase.execute(user, FormFixture.createUpdateFormRequest(FormType.NATIONAL_VETERANS)));
 
-        verify(formFacade, times(1)).getForm(formId);
+        verify(formFacade, times(1)).getForm(user);
     }
 
     @Test
@@ -71,14 +70,14 @@ class UpdateFormUseCaseTest {
         form.reject();
         User otherUser = UserFixture.createUser();
 
-        given(formFacade.getForm(form.getId())).willReturn(form);
+        given(formFacade.getForm(otherUser)).willReturn(form);
 
         // when and then
         assertThrows(AuthorityMismatchException.class, () ->
-                updateFormUseCase.execute(otherUser, form.getId(), FormFixture.createUpdateFormRequest(FormType.NATIONAL_VETERANS))
+                updateFormUseCase.execute(otherUser, FormFixture.createUpdateFormRequest(FormType.NATIONAL_VETERANS))
         );
 
-        verify(formFacade, times(1)).getForm(form.getId());
+        verify(formFacade, times(1)).getForm(otherUser);
     }
 
     @Test
@@ -87,13 +86,13 @@ class UpdateFormUseCaseTest {
         Form form = FormFixture.createForm(FormType.REGULAR);
         User user = form.getUser();
 
-        given(formFacade.getForm(form.getId())).willReturn(form);
+        given(formFacade.getForm(user)).willReturn(form);
 
         // when and then
         assertThrows(CannotUpdateNotRejectedFormException.class, () ->
-                updateFormUseCase.execute(user, form.getId(), FormFixture.createUpdateFormRequest(FormType.NATIONAL_VETERANS))
+                updateFormUseCase.execute(user, FormFixture.createUpdateFormRequest(FormType.NATIONAL_VETERANS))
         );
 
-        verify(formFacade, times(1)).getForm(form.getId());
+        verify(formFacade, times(1)).getForm(user);
     }
 }

--- a/src/test/java/com/bamdoliro/maru/presentation/form/FormControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/form/FormControllerTest.java
@@ -693,10 +693,10 @@ class FormControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        willDoNothing().given(updateFormUseCase).execute(user, formId, request);
+        willDoNothing().given(updateFormUseCase).execute(user, request);
 
 
-        mockMvc.perform(put("/forms/{form-id}", formId)
+        mockMvc.perform(put("/forms", formId)
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -709,10 +709,6 @@ class FormControllerTest extends RestDocsTestSupport {
                         requestHeaders(
                                 headerWithName(HttpHeaders.AUTHORIZATION)
                                         .description("Bearer token")
-                        ),
-                        pathParameters(
-                                parameterWithName("form-id")
-                                        .description("수정할 원서 id")
                         ),
                         requestFields(
                                 fieldWithPath("type")
@@ -849,7 +845,7 @@ class FormControllerTest extends RestDocsTestSupport {
                         )
                 ));
 
-        verify(updateFormUseCase, times(1)).execute(any(User.class), anyLong(), any(UpdateFormRequest.class));
+        verify(updateFormUseCase, times(1)).execute(any(User.class), any(UpdateFormRequest.class));
     }
 
     @Test
@@ -860,9 +856,9 @@ class FormControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        doThrow(new OutOfApplicationFormPeriodException()).when(updateFormUseCase).execute(any(User.class), anyLong(), any(UpdateFormRequest.class));
+        doThrow(new OutOfApplicationFormPeriodException()).when(updateFormUseCase).execute(any(User.class), any(UpdateFormRequest.class));
 
-        mockMvc.perform(put("/forms/{form-id}", formId)
+        mockMvc.perform(put("/forms", formId)
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -873,7 +869,7 @@ class FormControllerTest extends RestDocsTestSupport {
 
                 .andDo(restDocs.document());
 
-        verify(updateFormUseCase, times(1)).execute(any(User.class), anyLong(), any(UpdateFormRequest.class));
+        verify(updateFormUseCase, times(1)).execute(any(User.class), any(UpdateFormRequest.class));
     }
 
     @Test
@@ -883,10 +879,10 @@ class FormControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        doThrow(new FormNotFoundException()).when(updateFormUseCase).execute(any(User.class), anyLong(), any(UpdateFormRequest.class));
+        doThrow(new FormNotFoundException()).when(updateFormUseCase).execute(any(User.class), any(UpdateFormRequest.class));
 
 
-        mockMvc.perform(put("/forms/{form-id}", formId)
+        mockMvc.perform(put("/forms", formId)
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -897,7 +893,7 @@ class FormControllerTest extends RestDocsTestSupport {
 
                 .andDo(restDocs.document());
 
-        verify(updateFormUseCase, times(1)).execute(any(User.class), anyLong(), any(UpdateFormRequest.class));
+        verify(updateFormUseCase, times(1)).execute(any(User.class), any(UpdateFormRequest.class));
     }
 
     @Test
@@ -907,10 +903,10 @@ class FormControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        doThrow(new AuthorityMismatchException()).when(updateFormUseCase).execute(any(User.class), anyLong(), any(UpdateFormRequest.class));
+        doThrow(new AuthorityMismatchException()).when(updateFormUseCase).execute(any(User.class), any(UpdateFormRequest.class));
 
 
-        mockMvc.perform(put("/forms/{form-id}", formId)
+        mockMvc.perform(put("/forms", formId)
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -921,7 +917,7 @@ class FormControllerTest extends RestDocsTestSupport {
 
                 .andDo(restDocs.document());
 
-        verify(updateFormUseCase, times(1)).execute(any(User.class), anyLong(), any(UpdateFormRequest.class));
+        verify(updateFormUseCase, times(1)).execute(any(User.class), any(UpdateFormRequest.class));
     }
 
     @Test
@@ -931,10 +927,10 @@ class FormControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        doThrow(new CannotUpdateNotRejectedFormException()).when(updateFormUseCase).execute(any(User.class), anyLong(), any(UpdateFormRequest.class));
+        doThrow(new CannotUpdateNotRejectedFormException()).when(updateFormUseCase).execute(any(User.class), any(UpdateFormRequest.class));
 
 
-        mockMvc.perform(put("/forms/{form-id}", formId)
+        mockMvc.perform(put("/forms", formId)
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
                         .accept(MediaType.APPLICATION_JSON)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -945,7 +941,7 @@ class FormControllerTest extends RestDocsTestSupport {
 
                 .andDo(restDocs.document());
 
-        verify(updateFormUseCase, times(1)).execute(any(User.class), anyLong(), any(UpdateFormRequest.class));
+        verify(updateFormUseCase, times(1)).execute(any(User.class), any(UpdateFormRequest.class));
     }
 
     @Test


### PR DESCRIPTION
## 🎫 관련 이슈

close #39

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 반려 원서를 다시 제출하는 API를 수정했습니다.

<br>

## 🔨 작업 내용

- UpdateFormUseCase에서 userId를 제거
- Form내부 update 메서드에서 상태를 제출로 변경


<br>

## 🏁 확인 사항

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말

