### PR TITLE
[새기능] 어드민 원서 조회 시 1차 전형 점수 추가

### DIFF
--- a/src/main/java/com/bamdoliro/maru/presentation/form/dto/response/FormSimpleResponse.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/form/dto/response/FormSimpleResponse.java
@@ -25,6 +25,7 @@ public class FormSimpleResponse {
     private Boolean isChangedToRegular;
     private Double totalScore;
     private Boolean hasDocument;
+    private Double firstRoundScore;
     private Boolean firstRoundPassed;
     private Boolean secondRoundPassed;
 
@@ -40,6 +41,7 @@ public class FormSimpleResponse {
         this.isChangedToRegular = form.getChangedToRegular();
         this.totalScore = form.getScore().getTotalScore();
         this.hasDocument = form.isReceived();
+        this.firstRoundScore = form.getScore().getFirstRoundScore();
         this.firstRoundPassed = form.isFirstPassed();
         this.secondRoundPassed = form.isPassed();
     }


### PR DESCRIPTION
원서 조회할 때 1차 전형의 점수를 표시하기 위해 추가했습니다.

## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #36

<br>

## 📄 개요

> 원서 조회할 때 1차 전형 점수도 반환하도록 추가했습니다.

<br>

## 🔨 작업 내용

- FormSimpleResponse에 1차 전형 점수 필드를 추가했습니다.


<br>

## 🏁 확인 사항

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말

