### PR TITLE
[버그] 중복된 정보의 원서 제출이 불가능하도록 수정

### DIFF
--- a/src/main/java/com/bamdoliro/maru/domain/form/domain/value/Applicant.java
+++ b/src/main/java/com/bamdoliro/maru/domain/form/domain/value/Applicant.java
@@ -34,7 +34,7 @@ public class Applicant {
     private LocalDate birthday;
 
     @Convert(converter = StringEncryptedConverter.class)
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String registrationNumber;
 
     @Enumerated(EnumType.STRING)

--- a/src/test/java/com/bamdoliro/maru/shared/fixture/FormFixture.java
+++ b/src/test/java/com/bamdoliro/maru/shared/fixture/FormFixture.java
@@ -90,7 +90,7 @@ public class FormFixture {
                         "김밤돌",
                         new PhoneNumber("01012345678"),
                         LocalDate.of(2005, 4, 15),
-                        "070605-3111111",
+                        "070605-3111112",
                         Gender.MALE
                 ),
                 new Parent(
@@ -153,7 +153,7 @@ public class FormFixture {
                         "김밤돌",
                         new PhoneNumber("01085852525"),
                         LocalDate.of(2005, 4, 15),
-                        "070605-3111111",
+                        "070605-" + (3000000 + new Random().nextInt(9000000)),
                         Gender.FEMALE
                 ),
                 new Parent(
@@ -219,7 +219,7 @@ public class FormFixture {
                         "김밤돌",
                         new PhoneNumber("01085852525"),
                         LocalDate.of(2005, 4, 15),
-                        "070605-3111111",
+                        "070605-" + (3000000 + new Random().nextInt(9000000)),
                         Gender.FEMALE
                 ),
                 new Parent(
@@ -285,7 +285,7 @@ public class FormFixture {
                         "김밤돌",
                         new PhoneNumber("01012345678"),
                         LocalDate.of(2005, 4, 15),
-                        "070605-3111111",
+                        "070605-" + (3000000 + new Random().nextInt(9000000)),
                         Gender.FEMALE
                 ),
                 new Parent(
@@ -350,7 +350,7 @@ public class FormFixture {
                         "김밤돌",
                         new PhoneNumber("01012345678"),
                         LocalDate.of(2005, 4, 15),
-                        "070605-3111111",
+                        "070605-3111116",
                         Gender.FEMALE
                 ),
                 new Parent(
@@ -504,7 +504,7 @@ public class FormFixture {
                         "https://maru.com/photo.png",
                         "김밤돌",
                         "01012345678",
-                        "080409-3111111",
+                        "080409-3111117",
                         Gender.FEMALE
                 ),
                 new ParentResponse(
@@ -572,7 +572,7 @@ public class FormFixture {
                 "김밤돌",
                 "01012345678",
                 LocalDate.of(2005, 4, 15),
-                "070605-3111111",
+                "070605-3111118",
                 Gender.FEMALE
         );
     }


### PR DESCRIPTION
## 🎫 관련 이슈
close #49

<br>

## 📄 개요

> 주민등록번호 중복 검증을 추가했습니다.

<br>

## 🔨 작업 내용

- 주민등록번호 필드에 유니크 제약조건을 추가해서 중복된 정보의 원서가 저장될 수 없도록 수정했습니다.


<br>

## 🏁 확인 사항

- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
