### PR TITLE
[새기능] 지원자의 70%에 해당하는 지원자의 성적 조회 기능 추가

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/analysis/QueryGradeDistributionUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/analysis/QueryGradeDistributionUseCase.java
@@ -7,7 +7,9 @@ import com.bamdoliro.maru.presentation.analysis.dto.response.GradeDistributionRe
 import com.bamdoliro.maru.shared.annotation.UseCase;
 import lombok.RequiredArgsConstructor;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @UseCase
@@ -28,8 +30,35 @@ public class QueryGradeDistributionUseCase {
 
         for (FormType formType : FormType.values()) {
             if (!existingTypes.contains(formType)) {
-                result.add(new GradeDistributionResponse(formType, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
+                result.add(new GradeDistributionResponse(formType, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0));
             }
+        }
+
+        // 메인 카테고리별 70% 커트라인 계산
+        Map<FormType.Category, Double> firstRoundPercentiles = new HashMap<>();
+        Map<FormType.Category, Double> totalPercentiles = new HashMap<>();
+
+        List<FormType.Category> mainCategories = List.of(
+            FormType.Category.REGULAR,
+            FormType.Category.SPECIAL,
+            FormType.Category.SUPERNUMERARY
+        );
+
+        for (FormType.Category category : mainCategories) {
+            Double firstRoundPercentile = formRepository.findFirstRoundScoreAtPercentile(category, 0.7, request.getStatusList());
+            Double totalPercentile = formRepository.findTotalScoreAtPercentile(category, 0.7, request.getStatusList());
+
+            firstRoundPercentiles.put(category, firstRoundPercentile != null ? firstRoundPercentile : 0.0);
+            totalPercentiles.put(category, totalPercentile != null ? totalPercentile : 0.0);
+        }
+
+        // 각 전형별로 해당 카테고리의 70% 커트라인 설정
+        for (GradeDistributionResponse response : result) {
+            FormType.Category category = response.getType().getCategory();
+            response.setPercentiles(
+                firstRoundPercentiles.get(category),
+                totalPercentiles.get(category)
+            );
         }
 
         return result;

--- a/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryCustom.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryCustom.java
@@ -3,9 +3,9 @@ package com.bamdoliro.maru.infrastructure.persistence.form;
 import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.domain.type.FormStatus;
 import com.bamdoliro.maru.domain.form.domain.type.FormType;
-import com.bamdoliro.maru.infrastructure.persistence.form.vo.NumberOfApplicantsVo;
 import com.bamdoliro.maru.infrastructure.persistence.form.vo.FormUrlVo;
 import com.bamdoliro.maru.infrastructure.persistence.form.vo.GradeVo;
+import com.bamdoliro.maru.infrastructure.persistence.form.vo.NumberOfApplicantsVo;
 import com.bamdoliro.maru.infrastructure.persistence.form.vo.SchoolStatusVo;
 
 import java.util.List;
@@ -35,4 +35,6 @@ public interface FormRepositoryCustom {
     List<SchoolStatusVo> findSchoolByAddress(List<FormStatus> round, String keyword);
     List<SchoolStatusVo> findNotBusanSchool(List<FormStatus> round);
     List<Long> findAllExaminationNumber();
+    Double findFirstRoundScoreAtPercentile(FormType.Category category, double percentile, List<FormStatus> statusList);
+    Double findTotalScoreAtPercentile(FormType.Category category, double percentile, List<FormStatus> statusList);
 }

--- a/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryImpl.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/persistence/form/FormRepositoryImpl.java
@@ -337,4 +337,78 @@ public class FormRepositoryImpl implements FormRepositoryCustom {
                 .from(form)
                 .fetch();
     }
+
+    @Override
+    public Double findFirstRoundScoreAtPercentile(FormType.Category category, double percentile, List<FormStatus> statusList) {
+        List<FormType> matchingFormTypes = getFormTypesByCategory(category);
+
+        // 전체 개수 조회
+        long totalCount = queryFactory
+                .selectFrom(form)
+                .where(form.type.in(matchingFormTypes)
+                        .and(form.status.in(statusList))
+                        .and(form.score.firstRoundScore.isNotNull()))
+                .fetchCount();
+
+        if (totalCount == 0) {
+            return 0.0;
+        }
+
+        // 70% 지점 계산
+        long targetPosition = Math.round(totalCount * percentile);
+        if (targetPosition == 0) {
+            targetPosition = 1;
+        }
+
+        // OFFSET + LIMIT으로 해당 순위의 점수만 조회
+        Double score = queryFactory
+                .select(form.score.firstRoundScore)
+                .from(form)
+                .where(form.type.in(matchingFormTypes)
+                        .and(form.status.in(statusList))
+                        .and(form.score.firstRoundScore.isNotNull()))
+                .orderBy(form.score.firstRoundScore.desc())
+                .offset(targetPosition - 1)
+                .limit(1)
+                .fetchOne();
+
+        return score != null ? score : 0.0;
+    }
+
+    @Override
+    public Double findTotalScoreAtPercentile(FormType.Category category, double percentile, List<FormStatus> statusList) {
+        List<FormType> matchingFormTypes = getFormTypesByCategory(category);
+
+        // 전체 개수 조회
+        long totalCount = queryFactory
+                .selectFrom(form)
+                .where(form.type.in(matchingFormTypes)
+                        .and(form.status.in(statusList))
+                        .and(form.score.totalScore.isNotNull()))
+                .fetchCount();
+
+        if (totalCount == 0) {
+            return 0.0;
+        }
+
+        // 70% 지점 계산
+        long targetPosition = Math.round(totalCount * percentile);
+        if (targetPosition == 0) {
+            targetPosition = 1;
+        }
+
+        // OFFSET + LIMIT으로 해당 순위의 점수만 조회
+        Double score = queryFactory
+                .select(form.score.totalScore)
+                .from(form)
+                .where(form.type.in(matchingFormTypes)
+                        .and(form.status.in(statusList))
+                        .and(form.score.totalScore.isNotNull()))
+                .orderBy(form.score.totalScore.desc())
+                .offset(targetPosition - 1)
+                .limit(1)
+                .fetchOne();
+
+        return score != null ? score : 0.0;
+    }
 }

--- a/src/main/java/com/bamdoliro/maru/presentation/analysis/dto/response/GradeDistributionResponse.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/analysis/dto/response/GradeDistributionResponse.java
@@ -17,6 +17,8 @@ public class GradeDistributionResponse {
     private Double totalMax;
     private Double totalMin;
     private Double totalAvg;
+    private Double firstRoundSeventyPercentile;
+    private Double totalSeventyPercentile;
 
     public GradeDistributionResponse(GradeVo vo) {
         this.type = vo.getType();
@@ -26,5 +28,12 @@ public class GradeDistributionResponse {
         this.totalMax = vo.getTotalMax();
         this.totalMin = vo.getTotalMin();
         this.totalAvg = vo.getTotalAvg();
+        this.firstRoundSeventyPercentile = 0.0; // UseCase에서 설정
+        this.totalSeventyPercentile = 0.0; // UseCase에서 설정
+    }
+
+    public void setPercentiles(Double firstRoundSeventyPercentile, Double totalSeventyPercentile) {
+        this.firstRoundSeventyPercentile = firstRoundSeventyPercentile;
+        this.totalSeventyPercentile = totalSeventyPercentile;
     }
 }

--- a/src/test/java/com/bamdoliro/maru/application/analysis/QueryGradeDistributionUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/analysis/QueryGradeDistributionUseCaseTest.java
@@ -14,7 +14,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -40,8 +43,12 @@ class QueryGradeDistributionUseCaseTest {
         );
         List<FormStatus> round = List.of(FormStatus.FIRST_PASSED, FormStatus.FAILED, FormStatus.PASSED);
         given(formRepository.findGradeGroupByTypeAndStatus(round)).willReturn(voList);
+        given(formRepository.findFirstRoundScoreAtPercentile(any(FormType.Category.class), eq(0.7), eq(round)))
+            .willReturn(0.0);
+        given(formRepository.findTotalScoreAtPercentile(any(FormType.Category.class), eq(0.7), eq(round)))
+            .willReturn(0.0);
         GradeDistributionRequest request = new GradeDistributionRequest(round);
-        
+
         // when
         List<GradeDistributionResponse> responseList = queryGradeDistributionUseCase.execute(request);
 
@@ -66,6 +73,10 @@ class QueryGradeDistributionUseCaseTest {
         );
         List<FormStatus> round = List.of(FormStatus.FAILED, FormStatus.PASSED);
         given(formRepository.findGradeGroupByTypeAndStatus(round)).willReturn(voList);
+        given(formRepository.findFirstRoundScoreAtPercentile(any(FormType.Category.class), eq(0.7), eq(round)))
+            .willReturn(0.0);
+        given(formRepository.findTotalScoreAtPercentile(any(FormType.Category.class), eq(0.7), eq(round)))
+            .willReturn(0.0);
         GradeDistributionRequest request = new GradeDistributionRequest(round);
 
         // when
@@ -92,6 +103,10 @@ class QueryGradeDistributionUseCaseTest {
         );
         List<FormStatus> round = List.of(FormStatus.PASSED);
         given(formRepository.findGradeGroupByTypeAndStatus(round)).willReturn(voList);
+        given(formRepository.findFirstRoundScoreAtPercentile(any(FormType.Category.class), eq(0.7), eq(round)))
+            .willReturn(0.0);
+        given(formRepository.findTotalScoreAtPercentile(any(FormType.Category.class), eq(0.7), eq(round)))
+            .willReturn(0.0);
         GradeDistributionRequest request = new GradeDistributionRequest(round);
 
         // when
@@ -104,5 +119,139 @@ class QueryGradeDistributionUseCaseTest {
                 .toList()
                 .size(), voList.size());
         verify(formRepository, times(1)).findGradeGroupByTypeAndStatus(round);
+    }
+
+    @Test
+    void 성적분포와_70퍼센트_커트라인을_조회한다() {
+        // given
+        List<GradeVo> voList = List.of(
+            new GradeVo(FormType.REGULAR, 350.0, 200.0, 275.0, 600.0, 400.0, 500.0),
+            new GradeVo(FormType.NATIONAL_VETERANS, 340.0, 180.0, 260.0, 580.0, 380.0, 480.0)
+        );
+        List<FormStatus> round = List.of(FormStatus.RECEIVED, FormStatus.FIRST_PASSED);
+        GradeDistributionRequest request = new GradeDistributionRequest(round);
+
+        given(formRepository.findGradeGroupByTypeAndStatus(round)).willReturn(voList);
+        given(formRepository.findFirstRoundScoreAtPercentile(eq(FormType.Category.REGULAR), eq(0.7), eq(round)))
+            .willReturn(280.0);
+        given(formRepository.findTotalScoreAtPercentile(eq(FormType.Category.REGULAR), eq(0.7), eq(round)))
+            .willReturn(520.0);
+        given(formRepository.findFirstRoundScoreAtPercentile(eq(FormType.Category.SPECIAL), eq(0.7), eq(round)))
+            .willReturn(270.0);
+        given(formRepository.findTotalScoreAtPercentile(eq(FormType.Category.SPECIAL), eq(0.7), eq(round)))
+            .willReturn(510.0);
+        given(formRepository.findFirstRoundScoreAtPercentile(eq(FormType.Category.SUPERNUMERARY), eq(0.7), eq(round)))
+            .willReturn(0.0);
+        given(formRepository.findTotalScoreAtPercentile(eq(FormType.Category.SUPERNUMERARY), eq(0.7), eq(round)))
+            .willReturn(0.0);
+
+        // when
+        List<GradeDistributionResponse> result = queryGradeDistributionUseCase.execute(request);
+
+        // then
+        assertThat(result).hasSize(FormType.values().length);
+
+        GradeDistributionResponse regularResponse = result.stream()
+            .filter(r -> r.getType() == FormType.REGULAR)
+            .findFirst()
+            .orElseThrow();
+
+        assertThat(regularResponse.getFirstRoundMax()).isEqualTo(350.0);
+        assertThat(regularResponse.getFirstRoundSeventyPercentile()).isEqualTo(280.0);
+        assertThat(regularResponse.getTotalSeventyPercentile()).isEqualTo(520.0);
+
+        GradeDistributionResponse meisterTalentResponse = result.stream()
+            .filter(r -> r.getType() == FormType.NATIONAL_VETERANS)
+            .findFirst()
+            .orElseThrow();
+
+        assertThat(meisterTalentResponse.getFirstRoundSeventyPercentile()).isEqualTo(270.0);
+        assertThat(meisterTalentResponse.getTotalSeventyPercentile()).isEqualTo(510.0);
+    }
+
+    @Test
+    void 데이터가_없는_전형은_기본값으로_채워진다() {
+        // given
+        List<GradeVo> voList = List.of(
+            new GradeVo(FormType.REGULAR, 350.0, 200.0, 275.0, 600.0, 400.0, 500.0)
+        );
+        List<FormStatus> round = List.of(FormStatus.RECEIVED, FormStatus.FIRST_PASSED);
+        GradeDistributionRequest request = new GradeDistributionRequest(round);
+
+        given(formRepository.findGradeGroupByTypeAndStatus(round)).willReturn(voList);
+        given(formRepository.findFirstRoundScoreAtPercentile(any(FormType.Category.class), eq(0.7), eq(round)))
+            .willReturn(null);
+        given(formRepository.findTotalScoreAtPercentile(any(FormType.Category.class), eq(0.7), eq(round)))
+            .willReturn(null);
+
+        // when
+        List<GradeDistributionResponse> result = queryGradeDistributionUseCase.execute(request);
+
+        // then
+        assertThat(result).hasSize(FormType.values().length);
+
+        GradeDistributionResponse missingTypeResponse = result.stream()
+            .filter(r -> r.getType() == FormType.NATIONAL_VETERANS)
+            .findFirst()
+            .orElseThrow();
+
+        assertThat(missingTypeResponse.getFirstRoundMax()).isEqualTo(0.0);
+        assertThat(missingTypeResponse.getFirstRoundSeventyPercentile()).isEqualTo(0.0);
+        assertThat(missingTypeResponse.getTotalSeventyPercentile()).isEqualTo(0.0);
+    }
+
+    @Test
+    void 같은_카테고리의_전형들은_동일한_70퍼센트_커트라인을_가진다() {
+        // given
+        List<GradeVo> voList = List.of(
+            new GradeVo(FormType.REGULAR, 350.0, 200.0, 275.0, 600.0, 400.0, 500.0),
+            new GradeVo(FormType.NATIONAL_VETERANS, 340.0, 180.0, 260.0, 580.0, 380.0, 480.0),
+            new GradeVo(FormType.NATIONAL_BASIC_LIVING, 330.0, 170.0, 250.0, 570.0, 370.0, 470.0)
+        );
+        List<FormStatus> round = List.of(FormStatus.RECEIVED, FormStatus.FIRST_PASSED);
+        GradeDistributionRequest request = new GradeDistributionRequest(round);
+
+        given(formRepository.findGradeGroupByTypeAndStatus(round)).willReturn(voList);
+        given(formRepository.findFirstRoundScoreAtPercentile(eq(FormType.Category.REGULAR), eq(0.7), eq(round)))
+            .willReturn(280.0);
+        given(formRepository.findTotalScoreAtPercentile(eq(FormType.Category.REGULAR), eq(0.7), eq(round)))
+            .willReturn(520.0);
+        given(formRepository.findFirstRoundScoreAtPercentile(eq(FormType.Category.SPECIAL), eq(0.7), eq(round)))
+            .willReturn(270.0);
+        given(formRepository.findTotalScoreAtPercentile(eq(FormType.Category.SPECIAL), eq(0.7), eq(round)))
+            .willReturn(510.0);
+        given(formRepository.findFirstRoundScoreAtPercentile(eq(FormType.Category.SUPERNUMERARY), eq(0.7), eq(round)))
+            .willReturn(0.0);
+        given(formRepository.findTotalScoreAtPercentile(eq(FormType.Category.SUPERNUMERARY), eq(0.7), eq(round)))
+            .willReturn(0.0);
+
+        // when
+        List<GradeDistributionResponse> result = queryGradeDistributionUseCase.execute(request);
+
+        // then
+        GradeDistributionResponse regularResponse = result.stream()
+            .filter(r -> r.getType() == FormType.REGULAR)
+            .findFirst()
+            .orElseThrow();
+
+        GradeDistributionResponse meisterTalentResponse = result.stream()
+            .filter(r -> r.getType() == FormType.NATIONAL_VETERANS)
+            .findFirst()
+            .orElseThrow();
+
+        GradeDistributionResponse socialIntegrationResponse = result.stream()
+            .filter(r -> r.getType() == FormType.NATIONAL_BASIC_LIVING)
+            .findFirst()
+            .orElseThrow();
+
+        // REGULAR 카테고리는 REGULAR만 포함
+        assertThat(regularResponse.getFirstRoundSeventyPercentile()).isEqualTo(280.0);
+        assertThat(regularResponse.getTotalSeventyPercentile()).isEqualTo(520.0);
+
+        // SPECIAL 카테고리는 MEISTER_TALENT, SOCIAL_INTEGRATION 등을 포함
+        assertThat(meisterTalentResponse.getFirstRoundSeventyPercentile()).isEqualTo(270.0);
+        assertThat(meisterTalentResponse.getTotalSeventyPercentile()).isEqualTo(510.0);
+        assertThat(socialIntegrationResponse.getFirstRoundSeventyPercentile()).isEqualTo(270.0);
+        assertThat(socialIntegrationResponse.getTotalSeventyPercentile()).isEqualTo(510.0);
     }
 }

--- a/src/test/java/com/bamdoliro/maru/shared/fixture/AnalysisFixture.java
+++ b/src/test/java/com/bamdoliro/maru/shared/fixture/AnalysisFixture.java
@@ -26,7 +26,7 @@ public class AnalysisFixture {
     public static List<GradeDistributionResponse> createGradeDistributionResponseList() {
         List<GradeDistributionResponse> responseList = new ArrayList<>();
         for (FormType formType : FormType.values()) {
-            responseList.add(new GradeDistributionResponse(formType, randomDouble(0.0, 240.0), randomDouble(0.0, 240.0), randomDouble(0.0, 240.0), randomDouble(0.0, 240.0), randomDouble(0.0, 240.0), randomDouble(0.0, 240.0)));
+            responseList.add(new GradeDistributionResponse(formType, randomDouble(0.0, 240.0), randomDouble(0.0, 240.0), randomDouble(0.0, 240.0), randomDouble(0.0, 240.0), randomDouble(0.0, 240.0), randomDouble(0.0, 240.0), randomDouble(0.0, 240.0), randomDouble(0.0, 240.0)));
         }
         return responseList;
     }


### PR DESCRIPTION
## 🎫 관련 이슈

close #57

<br>

## 📄 개요

> 지원자의 70%에 해당하는 지원자의 성적 조회 기능 추가했습니다.

<br>

## 🔨 작업 내용

- 성적 분포 분석에 70% 성적 점수를 추가했습니다.


<br>

## 🏁 확인 사항
- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말

