### PR TITLE
[버그] 원서 저장할 때 학교대표번호가 저장되지 않음

### DIFF
--- a/src/main/java/com/bamdoliro/maru/presentation/form/dto/request/EducationRequest.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/form/dto/request/EducationRequest.java
@@ -47,7 +47,7 @@ public class EducationRequest {
 
     @Nullable
     @Size(max = 11, message = "11자 이하여야 합니다.")
-    private String teacherPhoneNumber;
+    private String schoolPhoneNumber;
 
     @Nullable
     @Size(max = 11, message = "11자 이하여야 합니다.")
@@ -65,7 +65,7 @@ public class EducationRequest {
                 ),
                 new Teacher(
                         teacherName,
-                        new PhoneNumber(teacherPhoneNumber),
+                        new PhoneNumber(schoolPhoneNumber),
                         new PhoneNumber(teacherMobilePhoneNumber)
                 )
         );

--- a/src/test/java/com/bamdoliro/maru/presentation/form/FormControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/form/FormControllerTest.java
@@ -127,7 +127,7 @@ class FormControllerTest extends RestDocsTestSupport {
                                 fieldWithPath("education.teacherName")
                                         .type(JsonFieldType.STRING)
                                         .description("작성 교사 (없는 경우 null)"),
-                                fieldWithPath("education.teacherPhoneNumber")
+                                fieldWithPath("education.schoolPhoneNumber")
                                         .type(JsonFieldType.STRING)
                                         .description("작성 교사 전화번호 (없는 경우 null)"),
                                 fieldWithPath("education.teacherMobilePhoneNumber")
@@ -768,7 +768,7 @@ class FormControllerTest extends RestDocsTestSupport {
                                 fieldWithPath("education.teacherName")
                                         .type(JsonFieldType.STRING)
                                         .description("작성 교사 (없는 경우 null)"),
-                                fieldWithPath("education.teacherPhoneNumber")
+                                fieldWithPath("education.schoolPhoneNumber")
                                         .type(JsonFieldType.STRING)
                                         .description("작성 교사 전화번호 (없는 경우 null)"),
                                 fieldWithPath("education.teacherMobilePhoneNumber")


### PR DESCRIPTION
## 🎫 관련 이슈

close #59

<br>

## 📄 개요

> 원서 저장할 때 학교대표번호가 저장되지 않음

<br>

## 🔨 작업 내용

- 원서 저장할 때 프론트의 값과 Request의 필드명이 달라 수정했습니다.


<br>

## 🏁 확인 사항
- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
