### PR TITLE
[버그] : 원서 전체 내보내기 시 NPE 발생

### DIFF
--- a/src/main/java/com/bamdoliro/maru/domain/form/domain/value/SubjectList.java
+++ b/src/main/java/com/bamdoliro/maru/domain/form/domain/value/SubjectList.java
@@ -1,10 +1,6 @@
 package com.bamdoliro.maru.domain.form.domain.value;
 
-import jakarta.persistence.CollectionTable;
-import jakarta.persistence.ElementCollection;
-import jakarta.persistence.Embeddable;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -24,7 +20,7 @@ public class SubjectList {
     private List<Subject> value;
 
     public static SubjectList of(List<Subject> subjectList) {
-        return new SubjectList(subjectList);
+        return new SubjectList(subjectList == null ? List.of() : subjectList);
     }
 
     public SubjectMap getSubjectMap() {


### PR DESCRIPTION
## 🎫 관련 이슈

close #65

<br>

## 📄 개요

> 원서 전체 내보내기 시 발생하는 NPE를 수정했습니다.

<br>

## 🔨 작업 내용

- subjectList가 널이면 빈 리스트를 반환하도록 했습니다.


<br>

## 🏁 확인 사항
- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말

