### PR TITLE
[개선] 타지역 50% 제한 제거

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/form/SelectFirstPassUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/SelectFirstPassUseCase.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 @RequiredArgsConstructor
@@ -19,7 +18,6 @@ public class SelectFirstPassUseCase {
 
     private final FormRepository formRepository;
     private final CalculateFormScoreService calculateFormScoreService;
-    private final AtomicInteger otherRegionCount = new AtomicInteger((int) (calculateMultiple(FixedNumber.TOTAL) * FixedNumber.OTHER_REGION_RATE));
 
     @Transactional
     public void execute() {
@@ -70,16 +68,8 @@ public class SelectFirstPassUseCase {
 
         for (Form form : formList) {
             if (count > 0) {
-                if (form.getEducation().getSchool().isBusan()) {
-                    form.firstPass();
-                    count--;
-                } else if (otherRegionCount.intValue() > 0) {
-                    form.firstPass();
-                    otherRegionCount.getAndDecrement();
-                    count--;
-                } else {
-                    action.accept(form);
-                }
+                form.firstPass();
+                count--;
             } else if (form.getScore().getFirstRoundScore().equals(lastScore)) {
                 form.firstPass();
             } else {

--- a/src/main/java/com/bamdoliro/maru/application/form/SelectSecondPassUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/SelectSecondPassUseCase.java
@@ -12,7 +12,6 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 @RequiredArgsConstructor
@@ -21,7 +20,6 @@ public class SelectSecondPassUseCase {
 
     private final FormRepository formRepository;
     private final CalculateFormScoreService calculateFormScoreService;
-    private final AtomicInteger otherRegionCount = new AtomicInteger((int) Math.ceil(FixedNumber.TOTAL * FixedNumber.OTHER_REGION_RATE));
 
     @Transactional
     public void execute() {
@@ -65,16 +63,8 @@ public class SelectSecondPassUseCase {
     private void processForms(List<Form> formList, int count, Consumer<Form> action) {
         for (Form form : formList) {
             if (count > 0) {
-                if (form.getEducation().getSchool().isBusan()) {
-                    form.pass();
-                    count--;
-                } else if (otherRegionCount.intValue() > 0) {
-                    form.pass();
-                    otherRegionCount.getAndDecrement();
-                    count--;
-                } else {
-                    action.accept(form);
-                }
+                form.pass();
+                count--;
             } else {
                 action.accept(form);
             }

--- a/src/main/java/com/bamdoliro/maru/shared/constants/FixedNumber.java
+++ b/src/main/java/com/bamdoliro/maru/shared/constants/FixedNumber.java
@@ -11,5 +11,4 @@ public class FixedNumber {
     public static final int SPECIAL_ADMISSION = 3;
     public static final int NATIONAL_VETERANS_EDUCATION = 5;
     public static final double MULTIPLE = 1.5;
-    public static final double OTHER_REGION_RATE = 0.5;
 }

--- a/src/test/java/com/bamdoliro/maru/application/form/SelectFirstPassUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/SelectFirstPassUseCaseTest.java
@@ -22,7 +22,6 @@ import java.util.Comparator;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
 @ActiveProfiles("test")
@@ -82,9 +81,7 @@ class SelectFirstPassUseCaseTest {
             log.info("status: {}", form.getStatus());
         });
         int passedFormCount = (int) formList.stream().filter(Form::isFirstPassedNow).count();
-        int passedOtherRegionFormCount = (int) formList.stream().filter(form -> form.isFirstPassedNow() && !form.getEducation().getSchool().isBusan()).count();
         int totalCount = (int) Math.ceil(FixedNumber.TOTAL * FixedNumber.MULTIPLE);
         assertEquals(totalCount, passedFormCount);
-        assertTrue(Math.ceil((double) totalCount / 2) >= passedOtherRegionFormCount);
     }
 }

--- a/src/test/java/com/bamdoliro/maru/application/form/SelectSecondPassUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/SelectSecondPassUseCaseTest.java
@@ -25,7 +25,6 @@ import java.util.Comparator;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Slf4j
 @ActiveProfiles("test")
@@ -99,9 +98,7 @@ public class SelectSecondPassUseCaseTest {
             log.info("status: {}", form.getStatus());
         });
         int passedFormCount = (int) formList.stream().filter(Form::isPassedNow).count();
-        int passedOtherRegionFormCount = (int) formList.stream().filter(form -> form.isPassedNow() && !form.getEducation().getSchool().isBusan()).count();
         assertEquals(FixedNumber.TOTAL, passedFormCount);
-        assertTrue(FixedNumber.TOTAL / 2 >= passedOtherRegionFormCount);
     }
 
     @Test


### PR DESCRIPTION
## 🎫 관련 이슈

close #77

<br>

## 📄 개요

> 1차 전형, 2차 전형 합격자를 산출할 때 타지역 50% 제한을 제거했습니다.

<br>

## 🔨 작업 내용

- 1차 전형, 2차 전형 합격자를 산출할 때 타지역 50% 제한을 제거했습니다.


<br>

## 🏁 확인 사항
- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
