### PR TITLE
[새기능] 입학 전형 요강 접근 시 다운로드

### DIFF
--- a/src/docs/asciidoc/notice.adoc
+++ b/src/docs/asciidoc/notice.adoc
@@ -116,3 +116,17 @@ include::{snippets}/notice-controller-test/공지사항을_삭제한다/http-req
 
 ===== 정상 응답
 include::{snippets}/notice-controller-test/공지사항을_삭제한다/http-response.adoc[]
+
+=== 입학전형요강 다운로드
+입학전형요강 PDF 파일을 다운로드할 수 있습니다.
+
+==== 요청
+include::{snippets}/notice-controller-test/입학전형요강을_다운로드한다/http-request.adoc[]
+
+==== 응답
+
+===== 정상 응답
+include::{snippets}/notice-controller-test/입학전형요강을_다운로드한다/http-response.adoc[]
+
+===== Response Body
+include::{snippets}/notice-controller-test/입학전형요강을_다운로드한다/response-fields.adoc[]

--- a/src/main/java/com/bamdoliro/maru/application/notice/DownloadAdmissionGuideUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/notice/DownloadAdmissionGuideUseCase.java
@@ -1,0 +1,21 @@
+package com.bamdoliro.maru.application.notice;
+
+import com.bamdoliro.maru.infrastructure.s3.FileService;
+import com.bamdoliro.maru.infrastructure.s3.constants.FolderConstant;
+import com.bamdoliro.maru.infrastructure.s3.dto.response.UrlResponse;
+import com.bamdoliro.maru.shared.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@UseCase
+public class DownloadAdmissionGuideUseCase {
+
+    private final FileService fileService;
+
+    private static final String ADMISSION_GUIDE_FILENAME = "2026학년도 해운대고등학교 입학전형요강.pdf";
+
+    public UrlResponse execute() {
+        String downloadUrl = fileService.getDownloadPresignedUrl(FolderConstant.ADMISSION_GUIDE, ADMISSION_GUIDE_FILENAME);
+        return new UrlResponse(null, downloadUrl);
+    }
+}

--- a/src/main/java/com/bamdoliro/maru/infrastructure/s3/constants/FolderConstant.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/s3/constants/FolderConstant.java
@@ -4,9 +4,10 @@ import lombok.experimental.UtilityClass;
 
 @UtilityClass
 public class FolderConstant {
-    
+
     public static final String IDENTIFICATION_PICTURE = "identification-picture";
     public static final String FORM = "form";
     public static final String NOTICE_FILE = "notice-file";
     public static final String ADMISSION_AND_PLEDGE = "admission-and-pledge";
+    public static final String ADMISSION_GUIDE = "admission-guide";
 }

--- a/src/main/java/com/bamdoliro/maru/presentation/notice/NoticeController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/notice/NoticeController.java
@@ -3,6 +3,7 @@ package com.bamdoliro.maru.presentation.notice;
 import com.bamdoliro.maru.application.notice.*;
 import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.infrastructure.s3.dto.request.FileMetadata;
+import com.bamdoliro.maru.infrastructure.s3.dto.response.UrlResponse;
 import com.bamdoliro.maru.presentation.notice.dto.request.NoticeRequest;
 import com.bamdoliro.maru.presentation.notice.dto.response.NoticeResponse;
 import com.bamdoliro.maru.presentation.notice.dto.response.NoticeSimpleResponse;
@@ -31,6 +32,7 @@ public class NoticeController {
     private final QueryNoticeUseCase queryNoticeUseCase;
     private final DeleteNoticeUseCase deleteNoticeUseCase;
     private final UploadFileUseCase uploadFileUseCase;
+    private final DownloadAdmissionGuideUseCase downloadAdmissionGuideUseCase;
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
@@ -85,5 +87,12 @@ public class NoticeController {
             @PathVariable(name = "notice-id") Long noticeId
     ) {
         deleteNoticeUseCase.execute(noticeId);
+    }
+
+    @GetMapping("/admission-guide")
+    public SingleCommonResponse<UrlResponse> downloadAdmissionGuide() {
+        return CommonResponse.ok(
+                downloadAdmissionGuideUseCase.execute()
+        );
     }
 }

--- a/src/test/java/com/bamdoliro/maru/application/notice/DownloadAdmissionGuideUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/notice/DownloadAdmissionGuideUseCaseTest.java
@@ -1,7 +1,6 @@
 package com.bamdoliro.maru.application.notice;
 
 import com.bamdoliro.maru.infrastructure.s3.FileService;
-import com.bamdoliro.maru.infrastructure.s3.constants.FolderConstant;
 import com.bamdoliro.maru.infrastructure.s3.dto.response.UrlResponse;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,8 +10,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.verify;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class DownloadAdmissionGuideUseCaseTest {
@@ -26,15 +25,16 @@ class DownloadAdmissionGuideUseCaseTest {
     @Test
     void 입학전형요강을_다운로드한다() {
         // given
-        String expectedUrl = "https://s3.amazonaws.com/haeundae-maru-s3-bucket/admission-guide/2026학년도%20해운대고등학교%20입학전형요강.pdf";
-        given(fileService.getDownloadPresignedUrl(FolderConstant.ADMISSION_GUIDE, "2026학년도 해운대고등학교 입학전형요강.pdf"))
-                .willReturn(expectedUrl);
+        String expectedUrl = "https://s3.amazonaws.com/haeundae-maru-s3-bucket/admission-guide/2026학년도 해운대고등학교 입학전형요강.pdf";
+        doReturn(expectedUrl)
+                .when(fileService)
+                .getDownloadPresignedUrl(anyString(), anyString());
 
         // when
         UrlResponse response = downloadAdmissionGuideUseCase.execute();
 
         // then
-        verify(fileService).getDownloadPresignedUrl(FolderConstant.ADMISSION_GUIDE, "2026학년도 해운대고등학교 입학전형요강.pdf");
+        verify(fileService, times(1)).getDownloadPresignedUrl(anyString(), anyString());
         assertEquals(expectedUrl, response.getDownloadUrl());
         assertNull(response.getUploadUrl());
     }
@@ -42,14 +42,15 @@ class DownloadAdmissionGuideUseCaseTest {
     @Test
     void 입학전형요강_파일이_존재하지_않으면_null을_반환한다() {
         // given
-        given(fileService.getDownloadPresignedUrl(FolderConstant.ADMISSION_GUIDE, "2026학년도 해운대고등학교 입학전형요강.pdf"))
-                .willReturn(null);
+        doReturn(null)
+                .when(fileService)
+                .getDownloadPresignedUrl(anyString(), anyString());
 
         // when
         UrlResponse response = downloadAdmissionGuideUseCase.execute();
 
         // then
-        verify(fileService).getDownloadPresignedUrl(FolderConstant.ADMISSION_GUIDE, "2026학년도 해운대고등학교 입학전형요강.pdf");
+        verify(fileService, times(1)).getDownloadPresignedUrl(anyString(), anyString());
         assertNull(response.getDownloadUrl());
         assertNull(response.getUploadUrl());
     }

--- a/src/test/java/com/bamdoliro/maru/application/notice/DownloadAdmissionGuideUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/notice/DownloadAdmissionGuideUseCaseTest.java
@@ -1,0 +1,56 @@
+package com.bamdoliro.maru.application.notice;
+
+import com.bamdoliro.maru.infrastructure.s3.FileService;
+import com.bamdoliro.maru.infrastructure.s3.constants.FolderConstant;
+import com.bamdoliro.maru.infrastructure.s3.dto.response.UrlResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class DownloadAdmissionGuideUseCaseTest {
+
+    @InjectMocks
+    private DownloadAdmissionGuideUseCase downloadAdmissionGuideUseCase;
+
+    @Mock
+    private FileService fileService;
+
+    @Test
+    void 입학전형요강을_다운로드한다() {
+        // given
+        String expectedUrl = "https://s3.amazonaws.com/haeundae-maru-s3-bucket/admission-guide/2026학년도%20해운대고등학교%20입학전형요강.pdf";
+        given(fileService.getDownloadPresignedUrl(FolderConstant.ADMISSION_GUIDE, "2026학년도 해운대고등학교 입학전형요강.pdf"))
+                .willReturn(expectedUrl);
+
+        // when
+        UrlResponse response = downloadAdmissionGuideUseCase.execute();
+
+        // then
+        verify(fileService).getDownloadPresignedUrl(FolderConstant.ADMISSION_GUIDE, "2026학년도 해운대고등학교 입학전형요강.pdf");
+        assertEquals(expectedUrl, response.getDownloadUrl());
+        assertNull(response.getUploadUrl());
+    }
+
+    @Test
+    void 입학전형요강_파일이_존재하지_않으면_null을_반환한다() {
+        // given
+        given(fileService.getDownloadPresignedUrl(FolderConstant.ADMISSION_GUIDE, "2026학년도 해운대고등학교 입학전형요강.pdf"))
+                .willReturn(null);
+
+        // when
+        UrlResponse response = downloadAdmissionGuideUseCase.execute();
+
+        // then
+        verify(fileService).getDownloadPresignedUrl(FolderConstant.ADMISSION_GUIDE, "2026학년도 해운대고등학교 입학전형요강.pdf");
+        assertNull(response.getDownloadUrl());
+        assertNull(response.getUploadUrl());
+    }
+}

--- a/src/test/java/com/bamdoliro/maru/presentation/notice/NoticeControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/notice/NoticeControllerTest.java
@@ -3,6 +3,7 @@ package com.bamdoliro.maru.presentation.notice;
 import com.bamdoliro.maru.domain.notice.exception.NoticeNotFoundException;
 import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.infrastructure.s3.dto.request.FileMetadata;
+import com.bamdoliro.maru.infrastructure.s3.dto.response.UrlResponse;
 import com.bamdoliro.maru.infrastructure.s3.exception.FileCountLimitExceededException;
 import com.bamdoliro.maru.presentation.notice.dto.request.NoticeRequest;
 import com.bamdoliro.maru.presentation.notice.dto.response.DownloadFileResponse;
@@ -30,7 +31,8 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.requestHe
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class NoticeControllerTest extends RestDocsTestSupport {
@@ -298,5 +300,20 @@ class NoticeControllerTest extends RestDocsTestSupport {
                 .andDo(restDocs.document());
 
         verify(uploadFileUseCase, times(1)).execute(anyList());
+    }
+
+    @Test
+    void 입학전형요강을_다운로드한다() throws Exception {
+        given(downloadAdmissionGuideUseCase.execute()).willReturn(
+                new UrlResponse(null, "https://maru.bamdoliro.com/admission-guide.pdf")
+        );
+
+        mockMvc.perform(get("/notices/admission-guide")
+                        .accept(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andDo(restDocs.document());
+
+        verify(downloadAdmissionGuideUseCase, times(1)).execute();
     }
 }

--- a/src/test/java/com/bamdoliro/maru/shared/util/ControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/shared/util/ControllerTest.java
@@ -140,6 +140,9 @@ public abstract class ControllerTest {
     protected QueryAllFormUseCase queryAllFormUseCase;
 
     @MockBean
+    protected DownloadAdmissionGuideUseCase downloadAdmissionGuideUseCase;
+
+    @MockBean
     protected QueryNoticeUseCase queryNoticeUseCase;
 
     @MockBean


### PR DESCRIPTION
## 🎫 관련 이슈

close #79

<br>

## 📄 개요

> 입학요강 다운로드 API 구현했습니다.

<br>

## 🔨 작업 내용

- 입학요강 다운로드 API를 구현했습니다.


<br>

## 🏁 확인 사항
- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
