### PR TITLE
[개선] 반려 후 원서 수정에 1차 전형 점수 수정되도록 수정

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/form/UpdateFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/UpdateFormUseCase.java
@@ -2,6 +2,7 @@ package com.bamdoliro.maru.application.form;
 
 import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.exception.CannotUpdateNotRejectedFormException;
+import com.bamdoliro.maru.domain.form.service.CalculateFormScoreService;
 import com.bamdoliro.maru.domain.form.service.FormFacade;
 import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.presentation.form.dto.request.UpdateFormRequest;
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UpdateFormUseCase {
 
     private final FormFacade formFacade;
+    private final CalculateFormScoreService calculateFormScoreService;
 
     @ValidateApplicationFormPeriod
     @Transactional
@@ -31,6 +33,9 @@ public class UpdateFormUseCase {
                 request.getDocument().toValue(),
                 request.getType()
         );
+
+        calculateFormScoreService.execute(form);
+
     }
 
     private void validateFormStatus(Form form) {

--- a/src/test/java/com/bamdoliro/maru/application/form/UpdateFormUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/UpdateFormUseCaseTest.java
@@ -5,6 +5,7 @@ import com.bamdoliro.maru.domain.form.domain.Form;
 import com.bamdoliro.maru.domain.form.domain.type.FormType;
 import com.bamdoliro.maru.domain.form.exception.CannotUpdateNotRejectedFormException;
 import com.bamdoliro.maru.domain.form.exception.FormNotFoundException;
+import com.bamdoliro.maru.domain.form.service.CalculateFormScoreService;
 import com.bamdoliro.maru.domain.form.service.FormFacade;
 import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.shared.fixture.FormFixture;
@@ -31,6 +32,8 @@ class UpdateFormUseCaseTest {
     @Mock
     private FormFacade formFacade;
 
+    @Mock
+    private CalculateFormScoreService calculateFormScoreService;
 
     @Test
     void 원서를_수정한다() {


### PR DESCRIPTION
## 🎫 관련 이슈

close #91

<br>

## 📄 개요

> 원서 수정에 1차 전형 점수 계산도 추가했습니다.

<br>

## 🔨 작업 내용

- UpdateFormUseCase에 CalculateFormScoreService를 추가했습니다.


<br>

## 🏁 확인 사항
- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
