### PR TITLE
[새기능] 입학설명회 신청자 삭제 기능

### DIFF
--- a/src/docs/asciidoc/fair.adoc
+++ b/src/docs/asciidoc/fair.adoc
@@ -151,3 +151,25 @@ include::{snippets}/fair-controller-test/입학설명회_신청자_명단을_엑
 
 ===== 입학설명회가 없는 경우
 include::{snippets}/fair-controller-test/입학설명회_신청자_명단을_엑셀로_다운받을_때_입학설명회가_없으면_에러가_발생한다/http-response.adoc[]
+
+=== 입학설명회 신청자 삭제
+어드민은 입학설명회 신청자를 삭제할 수 있습니다.
+
+==== 요청 형식
+
+===== Request Header
+include::{snippets}/fair-controller-test/입학설명회_신청자를_삭제한다/request-headers.adoc[]
+
+===== Path Parameter
+include::{snippets}/fair-controller-test/입학설명회_신청자를_삭제한다/path-parameters.adoc[]
+
+===== 요청
+include::{snippets}/fair-controller-test/입학설명회_신청자를_삭제한다/http-request.adoc[]
+
+==== 응답
+
+===== 정상 응답
+include::{snippets}/fair-controller-test/입학설명회_신청자를_삭제한다/http-response.adoc[]
+
+===== 신청자가 없는 경우
+include::{snippets}/fair-controller-test/입학설명회_신청자를_삭제할_때_신청자가_없으면_에러가_발생한다/http-response.adoc[]

--- a/src/main/java/com/bamdoliro/maru/application/fair/AttendAdmissionFairUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/fair/AttendAdmissionFairUseCase.java
@@ -58,7 +58,7 @@ public class AttendAdmissionFairUseCase {
     private void sendMessage(Fair fair, Attendee attendee) {
         String message = String.format("""
                 안녕하세요, %s 님.
-                부산소프트웨어마이스터고 입학설명회 신청이 완료되었습니다.
+                해운대고등학교 입학설명회 신청이 완료되었습니다.
 
                 일시: %s
                 장소: %s

--- a/src/main/java/com/bamdoliro/maru/application/fair/DeleteAttendeeUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/fair/DeleteAttendeeUseCase.java
@@ -1,0 +1,37 @@
+package com.bamdoliro.maru.application.fair;
+
+import com.bamdoliro.maru.domain.fair.domain.Attendee;
+import com.bamdoliro.maru.domain.fair.domain.Fair;
+import com.bamdoliro.maru.domain.fair.exception.AttendeeNotFoundException;
+import com.bamdoliro.maru.infrastructure.persistence.fair.AttendeeRepository;
+import com.bamdoliro.maru.shared.annotation.UseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@UseCase
+public class DeleteAttendeeUseCase {
+
+    private final FairFacade fairFacade;
+    private final AttendeeRepository attendeeRepository;
+
+    @Transactional
+    public void execute(Long fairId, Long attendeeId) {
+        Fair fair = fairFacade.getFair(fairId);
+        Attendee attendee = getAttendee(attendeeId);
+        validateAttendeeInFair(fair, attendee);
+
+        attendeeRepository.delete(attendee);
+    }
+
+    private Attendee getAttendee(Long attendeeId) {
+        return attendeeRepository.findById(attendeeId)
+                .orElseThrow(AttendeeNotFoundException::new);
+    }
+
+    private void validateAttendeeInFair(Fair fair, Attendee attendee) {
+        if (!attendee.getFair().getId().equals(fair.getId())) {
+            throw new AttendeeNotFoundException();
+        }
+    }
+}

--- a/src/main/java/com/bamdoliro/maru/domain/fair/exception/AttendeeNotFoundException.java
+++ b/src/main/java/com/bamdoliro/maru/domain/fair/exception/AttendeeNotFoundException.java
@@ -1,0 +1,11 @@
+package com.bamdoliro.maru.domain.fair.exception;
+
+import com.bamdoliro.maru.domain.fair.exception.error.FairErrorProperty;
+import com.bamdoliro.maru.shared.error.MaruException;
+
+public class AttendeeNotFoundException extends MaruException {
+
+    public AttendeeNotFoundException() {
+        super(FairErrorProperty.ATTENDEE_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/bamdoliro/maru/domain/fair/exception/error/FairErrorProperty.java
+++ b/src/main/java/com/bamdoliro/maru/domain/fair/exception/error/FairErrorProperty.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum FairErrorProperty implements ErrorProperty {
     FAIR_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 설명회를 찾을 수 없습니다."),
+    ATTENDEE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 신청자를 찾을 수 없습니다."),
     HEADCOUNT_EXCEEDED(HttpStatus.CONFLICT, "설명회 신청 인원이 초과되었습니다."),
     NOT_APPLICATION_PERIOD(HttpStatus.CONFLICT, "신청 기간이 아닙니다.");
 

--- a/src/main/java/com/bamdoliro/maru/presentation/fair/FairController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/fair/FairController.java
@@ -35,6 +35,7 @@ public class FairController {
     private final QueryFairListUseCase queryFairListUseCase;
     private final QueryFairDetailUseCase queryFairDetailUseCase;
     private final ExportAttendeeListUseCase exportAttendeeListUseCase;
+    private final DeleteAttendeeUseCase deleteAttendeeUseCase;
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
@@ -100,5 +101,14 @@ public class FairController {
         return ResponseEntity.ok()
                 .contentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
                 .body(exportAttendeeListUseCase.execute(fairId));
+    }
+
+    @DeleteMapping("/{fair-id}/attendees/{attendee-id}")
+    public void deleteAttendee(
+            @AuthenticationPrincipal(authority = Authority.ADMIN) User user,
+            @PathVariable(name = "fair-id") Long fairId,
+            @PathVariable(name = "attendee-id") Long attendeeId
+    ){
+        deleteAttendeeUseCase.execute(fairId, attendeeId);
     }
 }

--- a/src/test/java/com/bamdoliro/maru/application/fair/DeleteAttendeeUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/fair/DeleteAttendeeUseCaseTest.java
@@ -1,0 +1,98 @@
+package com.bamdoliro.maru.application.fair;
+
+import com.bamdoliro.maru.domain.fair.domain.Attendee;
+import com.bamdoliro.maru.domain.fair.domain.Fair;
+import com.bamdoliro.maru.domain.fair.exception.AttendeeNotFoundException;
+import com.bamdoliro.maru.infrastructure.persistence.fair.AttendeeRepository;
+import com.bamdoliro.maru.shared.fixture.FairFixture;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class DeleteAttendeeUseCaseTest {
+
+    @InjectMocks
+    private DeleteAttendeeUseCase deleteAttendeeUseCase;
+
+    @Mock
+    private FairFacade fairFacade;
+
+    @Mock
+    private AttendeeRepository attendeeRepository;
+
+    @Test
+    void 신청자를_삭제한다() throws Exception {
+        // given
+        Long fairId = 1L;
+        Long attendeeId = 1L;
+
+        Fair fair = FairFixture.createFair();
+        ReflectionTestUtils.setField(fair, "id", fairId); // ID 설정 추가
+
+        Attendee attendee = FairFixture.createAttendee(fair);
+
+        given(fairFacade.getFair(fairId)).willReturn(fair);
+        given(attendeeRepository.findById(attendeeId)).willReturn(Optional.of(attendee));
+        willDoNothing().given(attendeeRepository).delete(attendee);
+
+        // when
+        deleteAttendeeUseCase.execute(fairId, attendeeId);
+
+        // then
+        verify(fairFacade, times(1)).getFair(fairId);
+        verify(attendeeRepository, times(1)).findById(attendeeId);
+        verify(attendeeRepository, times(1)).delete(attendee);
+    }
+
+    @Test
+    void 존재하지_않는_신청자_삭제시_예외가_발생한다() throws Exception {
+        // given
+        Long fairId = 1L;
+        Long attendeeId = 1L;
+
+        Fair fair = FairFixture.createFair();
+
+        given(fairFacade.getFair(fairId)).willReturn(fair);
+        given(attendeeRepository.findById(attendeeId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThrows(AttendeeNotFoundException.class, () -> {
+            deleteAttendeeUseCase.execute(fairId, attendeeId);
+        });
+    }
+
+    @Test
+    void 다른_설명회의_신청자_삭제시_예외가_발생한다() throws Exception {
+        // given
+        Long fairId = 1L;
+        Long attendeeId = 1L;
+
+        Fair fair = FairFixture.createFair();
+        Fair anotherFair = FairFixture.createAnotherFair();
+
+        ReflectionTestUtils.setField(fair, "id", fairId);
+        ReflectionTestUtils.setField(anotherFair, "id", 2L); // 다른 ID
+
+        Attendee attendee = FairFixture.createAttendee(anotherFair);
+
+        given(fairFacade.getFair(fairId)).willReturn(fair);
+        given(attendeeRepository.findById(attendeeId)).willReturn(Optional.of(attendee));
+
+        // when & then
+        assertThrows(AttendeeNotFoundException.class, () -> {
+            deleteAttendeeUseCase.execute(fairId, attendeeId);
+        });
+    }
+}

--- a/src/test/java/com/bamdoliro/maru/presentation/fair/FairControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/fair/FairControllerTest.java
@@ -1,6 +1,7 @@
 package com.bamdoliro.maru.presentation.fair;
 
 import com.bamdoliro.maru.domain.fair.domain.type.FairType;
+import com.bamdoliro.maru.domain.fair.exception.AttendeeNotFoundException;
 import com.bamdoliro.maru.domain.fair.exception.FairNotFoundException;
 import com.bamdoliro.maru.domain.fair.exception.HeadcountExceededException;
 import com.bamdoliro.maru.domain.fair.exception.NotApplicationPeriodException;
@@ -417,5 +418,58 @@ class FairControllerTest extends RestDocsTestSupport {
                 .andDo(restDocs.document());
 
         verify(exportAttendeeListUseCase, times(1)).execute(fairId);
+    }
+
+    @Test
+    void 입학설명회_신청자를_삭제한다() throws Exception {
+        Long fairId = 1L;
+        Long attendeeId = 1L;
+        User user = UserFixture.createAdminUser();
+
+        given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
+        given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
+        willDoNothing().given(deleteAttendeeUseCase).execute(fairId, attendeeId);
+
+        mockMvc.perform(delete("/fairs/{fair-id}/attendees/{attendee-id}", fairId, attendeeId)
+                        .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
+                        .accept(MediaType.APPLICATION_JSON))
+
+                .andExpect(status().isOk())
+
+                .andDo(restDocs.document(
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION)
+                                        .description("Bearer token")
+                        ),
+                        pathParameters(
+                                parameterWithName("fair-id")
+                                        .description("입학설명회 id"),
+                                parameterWithName("attendee-id")
+                                        .description("신청자 id")
+                        )
+                ));
+
+        verify(deleteAttendeeUseCase, times(1)).execute(fairId, attendeeId);
+    }
+
+    @Test
+    void 입학설명회_신청자를_삭제할_때_신청자가_없으면_에러가_발생한다() throws Exception {
+        Long fairId = 1L;
+        Long attendeeId = -1L;
+        User user = UserFixture.createAdminUser();
+
+        given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
+        given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
+        willThrow(new AttendeeNotFoundException()).given(deleteAttendeeUseCase).execute(fairId, attendeeId);
+
+        mockMvc.perform(delete("/fairs/{fair-id}/attendees/{attendee-id}", fairId, attendeeId)
+                        .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
+                        .accept(MediaType.APPLICATION_JSON))
+
+                .andExpect(status().isNotFound())
+
+                .andDo(restDocs.document());
+
+        verify(deleteAttendeeUseCase, times(1)).execute(fairId, attendeeId);
     }
 }

--- a/src/test/java/com/bamdoliro/maru/shared/fixture/FairFixture.java
+++ b/src/test/java/com/bamdoliro/maru/shared/fixture/FairFixture.java
@@ -26,6 +26,18 @@ public class FairFixture {
                 LocalDate.now().plusWeeks(2)
         );
     }
+
+    public static Fair createAnotherFair() {
+        return new Fair(
+                LocalDateTime.now().plusWeeks(2),
+                130,
+                "해운대고등학교 5층 대동관",
+                FairType.STUDENT_AND_PARENT,
+                LocalDate.now(),
+                LocalDate.now().plusWeeks(1)
+        );
+    }
+
     public static CreateFairRequest createFairRequest() {
         return new CreateFairRequest(
                 LocalDateTime.now().plusWeeks(3),

--- a/src/test/java/com/bamdoliro/maru/shared/util/ControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/shared/util/ControllerTest.java
@@ -188,6 +188,9 @@ public abstract class ControllerTest {
     protected CreateAdmissionFairUseCase createAdmissionFairUseCase;
 
     @MockBean
+    protected DeleteAttendeeUseCase deleteAttendeeUseCase;
+
+    @MockBean
     protected AttendAdmissionFairUseCase attendAdmissionFairUseCase;
 
     @MockBean


### PR DESCRIPTION
## 🎫 관련 이슈

close #116

<br>

## 📄 개요

> 입학설명회 신청자 삭제 기능을 만들었습니다.

<br>

## 🔨 작업 내용

- 입학설명회 삭제 기능을 추가했습니다.


<br>

## 🏁 확인 사항
- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말