### PR TITLE
[개선] 입학설명회 신청자 삭제 방식 수정

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/fair/DeleteAttendeeUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/fair/DeleteAttendeeUseCase.java
@@ -1,12 +1,16 @@
 package com.bamdoliro.maru.application.fair;
 
 import com.bamdoliro.maru.domain.fair.domain.Attendee;
-import com.bamdoliro.maru.domain.fair.domain.Fair;
 import com.bamdoliro.maru.domain.fair.exception.AttendeeNotFoundException;
 import com.bamdoliro.maru.infrastructure.persistence.fair.AttendeeRepository;
+import com.bamdoliro.maru.presentation.fair.dto.request.DeleteAttendeeListRequest;
+import com.bamdoliro.maru.presentation.fair.dto.request.DeleteAttendeeRequest;
 import com.bamdoliro.maru.shared.annotation.UseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
 
 @RequiredArgsConstructor
 @UseCase
@@ -16,22 +20,32 @@ public class DeleteAttendeeUseCase {
     private final AttendeeRepository attendeeRepository;
 
     @Transactional
-    public void execute(Long fairId, Long attendeeId) {
-        Fair fair = fairFacade.getFair(fairId);
-        Attendee attendee = getAttendee(attendeeId);
-        validateAttendeeInFair(fair, attendee);
+    public void execute(Long fairId, DeleteAttendeeListRequest request) {
+        List<DeleteAttendeeRequest> requestList = getSortedList(request);
+        List<Attendee> attendeeList = attendeeRepository.findByAttendeeIdList(
+                requestList.stream()
+                        .map(DeleteAttendeeRequest::getAttendeeId)
+                        .toList()
+        );
 
-        attendeeRepository.delete(attendee);
+        for (int i = 0; i < attendeeList.size(); i++) {
+            Attendee attendee = attendeeList.get(i);
+
+            validateAttendeeInFair(fairId, attendee);
+
+            attendeeRepository.deleteById(attendee.getId());
+        }
     }
 
-    private Attendee getAttendee(Long attendeeId) {
-        return attendeeRepository.findById(attendeeId)
-                .orElseThrow(AttendeeNotFoundException::new);
-    }
-
-    private void validateAttendeeInFair(Fair fair, Attendee attendee) {
-        if (!attendee.getFair().getId().equals(fair.getId())) {
+    private void validateAttendeeInFair(Long fairId, Attendee attendee) {
+        if (!attendee.getFair().getId().equals(fairId)) {
             throw new AttendeeNotFoundException();
         }
+    }
+
+    private List<DeleteAttendeeRequest> getSortedList(DeleteAttendeeListRequest request) {
+        return request.getAttendeeList().stream()
+                .sorted(Comparator.comparingLong(DeleteAttendeeRequest::getAttendeeId))
+                .toList();
     }
 }

--- a/src/main/java/com/bamdoliro/maru/infrastructure/persistence/fair/AttendeeRepository.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/persistence/fair/AttendeeRepository.java
@@ -4,7 +4,7 @@ import com.bamdoliro.maru.domain.fair.domain.Attendee;
 import com.bamdoliro.maru.domain.fair.domain.Fair;
 import org.springframework.data.repository.CrudRepository;
 
-public interface AttendeeRepository extends CrudRepository<Attendee, Long> {
+public interface AttendeeRepository extends CrudRepository<Attendee, Long>, AttendeeRepositoryCustom {
 
     Integer countByFair(Fair fair);
 }

--- a/src/main/java/com/bamdoliro/maru/infrastructure/persistence/fair/AttendeeRepositoryCustom.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/persistence/fair/AttendeeRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.bamdoliro.maru.infrastructure.persistence.fair;
+
+import com.bamdoliro.maru.domain.fair.domain.Attendee;
+
+import java.util.List;
+
+public interface AttendeeRepositoryCustom {
+
+    List<Attendee> findByAttendeeIdList(List<Long> idList);
+}

--- a/src/main/java/com/bamdoliro/maru/infrastructure/persistence/fair/AttendeeRepositoryImpl.java
+++ b/src/main/java/com/bamdoliro/maru/infrastructure/persistence/fair/AttendeeRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.bamdoliro.maru.infrastructure.persistence.fair;
+
+import com.bamdoliro.maru.domain.fair.domain.Attendee;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.bamdoliro.maru.domain.fair.domain.QAttendee.attendee;
+
+@Repository
+@RequiredArgsConstructor
+public class AttendeeRepositoryImpl implements AttendeeRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Attendee> findByAttendeeIdList(List<Long> idList) {
+        return queryFactory
+                .selectFrom(attendee)
+                .where(attendee.id.in(idList))
+                .orderBy(attendee.id.asc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/bamdoliro/maru/presentation/fair/FairController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/fair/FairController.java
@@ -5,6 +5,7 @@ import com.bamdoliro.maru.domain.fair.domain.type.FairType;
 import com.bamdoliro.maru.domain.user.domain.User;
 import com.bamdoliro.maru.presentation.fair.dto.request.AttendAdmissionFairRequest;
 import com.bamdoliro.maru.presentation.fair.dto.request.CreateFairRequest;
+import com.bamdoliro.maru.presentation.fair.dto.request.DeleteAttendeeListRequest;
 import com.bamdoliro.maru.presentation.fair.dto.request.UpdateFairRequest;
 import com.bamdoliro.maru.presentation.fair.dto.response.FairDetailResponse;
 import com.bamdoliro.maru.presentation.fair.dto.response.FairResponse;
@@ -103,12 +104,13 @@ public class FairController {
                 .body(exportAttendeeListUseCase.execute(fairId));
     }
 
-    @DeleteMapping("/{fair-id}/attendees/{attendee-id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/{fair-id}/attendees")
     public void deleteAttendee(
             @AuthenticationPrincipal(authority = Authority.ADMIN) User user,
             @PathVariable(name = "fair-id") Long fairId,
-            @PathVariable(name = "attendee-id") Long attendeeId
+            @RequestBody @Valid DeleteAttendeeListRequest request
     ){
-        deleteAttendeeUseCase.execute(fairId, attendeeId);
+        deleteAttendeeUseCase.execute(fairId, request);
     }
 }

--- a/src/main/java/com/bamdoliro/maru/presentation/fair/dto/request/DeleteAttendeeListRequest.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/fair/dto/request/DeleteAttendeeListRequest.java
@@ -1,0 +1,18 @@
+package com.bamdoliro.maru.presentation.fair.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeleteAttendeeListRequest {
+
+    @NotEmpty(message = "필수값입니다.")
+    private List<@Valid DeleteAttendeeRequest> attendeeList;
+}

--- a/src/main/java/com/bamdoliro/maru/presentation/fair/dto/request/DeleteAttendeeRequest.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/fair/dto/request/DeleteAttendeeRequest.java
@@ -1,0 +1,19 @@
+package com.bamdoliro.maru.presentation.fair.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DeleteAttendeeRequest {
+
+    @Min(value = 1, message = "1 이상이어야 합니다.")
+    @Max(value = 10000, message = "10000 이하여야 합니다.")
+    @NotNull(message = "필수값입니다.")
+    private Long attendeeId;
+}

--- a/src/test/java/com/bamdoliro/maru/application/fair/DeleteAttendeeUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/fair/DeleteAttendeeUseCaseTest.java
@@ -4,6 +4,8 @@ import com.bamdoliro.maru.domain.fair.domain.Attendee;
 import com.bamdoliro.maru.domain.fair.domain.Fair;
 import com.bamdoliro.maru.domain.fair.exception.AttendeeNotFoundException;
 import com.bamdoliro.maru.infrastructure.persistence.fair.AttendeeRepository;
+import com.bamdoliro.maru.presentation.fair.dto.request.DeleteAttendeeListRequest;
+import com.bamdoliro.maru.presentation.fair.dto.request.DeleteAttendeeRequest;
 import com.bamdoliro.maru.shared.fixture.FairFixture;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,7 +14,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import java.util.Optional;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
@@ -39,21 +41,23 @@ public class DeleteAttendeeUseCaseTest {
         Long attendeeId = 1L;
 
         Fair fair = FairFixture.createFair();
-        ReflectionTestUtils.setField(fair, "id", fairId); // ID 설정 추가
+        ReflectionTestUtils.setField(fair, "id", fairId);
 
         Attendee attendee = FairFixture.createAttendee(fair);
+        ReflectionTestUtils.setField(attendee, "id", attendeeId);
 
-        given(fairFacade.getFair(fairId)).willReturn(fair);
-        given(attendeeRepository.findById(attendeeId)).willReturn(Optional.of(attendee));
-        willDoNothing().given(attendeeRepository).delete(attendee);
+        DeleteAttendeeRequest deleteAttendeeRequest = new DeleteAttendeeRequest(attendeeId);
+        DeleteAttendeeListRequest request = new DeleteAttendeeListRequest(List.of(deleteAttendeeRequest));
+
+        given(attendeeRepository.findByAttendeeIdList(List.of(attendeeId))).willReturn(List.of(attendee));
+        willDoNothing().given(attendeeRepository).deleteById(attendeeId);
 
         // when
-        deleteAttendeeUseCase.execute(fairId, attendeeId);
+        deleteAttendeeUseCase.execute(fairId, request);
 
         // then
-        verify(fairFacade, times(1)).getFair(fairId);
-        verify(attendeeRepository, times(1)).findById(attendeeId);
-        verify(attendeeRepository, times(1)).delete(attendee);
+        verify(attendeeRepository, times(1)).findByAttendeeIdList(List.of(attendeeId));
+        verify(attendeeRepository, times(1)).deleteById(attendeeId);
     }
 
     @Test
@@ -62,14 +66,14 @@ public class DeleteAttendeeUseCaseTest {
         Long fairId = 1L;
         Long attendeeId = 1L;
 
-        Fair fair = FairFixture.createFair();
+        DeleteAttendeeRequest deleteAttendeeRequest = new DeleteAttendeeRequest(attendeeId);
+        DeleteAttendeeListRequest request = new DeleteAttendeeListRequest(List.of(deleteAttendeeRequest));
 
-        given(fairFacade.getFair(fairId)).willReturn(fair);
-        given(attendeeRepository.findById(attendeeId)).willReturn(Optional.empty());
+        given(attendeeRepository.findByAttendeeIdList(List.of(attendeeId))).willReturn(List.of());
 
         // when & then
-        assertThrows(AttendeeNotFoundException.class, () -> {
-            deleteAttendeeUseCase.execute(fairId, attendeeId);
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            deleteAttendeeUseCase.execute(fairId, request);
         });
     }
 
@@ -83,16 +87,19 @@ public class DeleteAttendeeUseCaseTest {
         Fair anotherFair = FairFixture.createAnotherFair();
 
         ReflectionTestUtils.setField(fair, "id", fairId);
-        ReflectionTestUtils.setField(anotherFair, "id", 2L); // 다른 ID
+        ReflectionTestUtils.setField(anotherFair, "id", 2L);
 
         Attendee attendee = FairFixture.createAttendee(anotherFair);
+        ReflectionTestUtils.setField(attendee, "id", attendeeId);
 
-        given(fairFacade.getFair(fairId)).willReturn(fair);
-        given(attendeeRepository.findById(attendeeId)).willReturn(Optional.of(attendee));
+        DeleteAttendeeRequest deleteAttendeeRequest = new DeleteAttendeeRequest(attendeeId);
+        DeleteAttendeeListRequest request = new DeleteAttendeeListRequest(List.of(deleteAttendeeRequest));
+
+        given(attendeeRepository.findByAttendeeIdList(List.of(attendeeId))).willReturn(List.of(attendee));
 
         // when & then
         assertThrows(AttendeeNotFoundException.class, () -> {
-            deleteAttendeeUseCase.execute(fairId, attendeeId);
+            deleteAttendeeUseCase.execute(fairId, request);
         });
     }
 }

--- a/src/test/java/com/bamdoliro/maru/application/fair/DeleteAttendeeUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/fair/DeleteAttendeeUseCaseTest.java
@@ -17,10 +17,10 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class DeleteAttendeeUseCaseTest {
@@ -61,7 +61,7 @@ public class DeleteAttendeeUseCaseTest {
     }
 
     @Test
-    void 존재하지_않는_신청자_삭제시_예외가_발생한다() throws Exception {
+    void 존재하지_않는_신청자_삭제시_아무_일도_일어나지_않는다() throws Exception {
         // given
         Long fairId = 1L;
         Long attendeeId = 1L;
@@ -72,9 +72,10 @@ public class DeleteAttendeeUseCaseTest {
         given(attendeeRepository.findByAttendeeIdList(List.of(attendeeId))).willReturn(List.of());
 
         // when & then
-        assertThrows(IndexOutOfBoundsException.class, () -> {
-            deleteAttendeeUseCase.execute(fairId, request);
-        });
+        deleteAttendeeUseCase.execute(fairId, request);
+
+        verify(attendeeRepository, times(1)).findByAttendeeIdList(List.of(attendeeId));
+        verify(attendeeRepository, never()).deleteById(any());
     }
 
     @Test

--- a/src/test/java/com/bamdoliro/maru/presentation/fair/FairControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/fair/FairControllerTest.java
@@ -1,14 +1,11 @@
 package com.bamdoliro.maru.presentation.fair;
 
 import com.bamdoliro.maru.domain.fair.domain.type.FairType;
-import com.bamdoliro.maru.domain.fair.exception.AttendeeNotFoundException;
 import com.bamdoliro.maru.domain.fair.exception.FairNotFoundException;
 import com.bamdoliro.maru.domain.fair.exception.HeadcountExceededException;
 import com.bamdoliro.maru.domain.fair.exception.NotApplicationPeriodException;
 import com.bamdoliro.maru.domain.user.domain.User;
-import com.bamdoliro.maru.presentation.fair.dto.request.AttendAdmissionFairRequest;
-import com.bamdoliro.maru.presentation.fair.dto.request.CreateFairRequest;
-import com.bamdoliro.maru.presentation.fair.dto.request.UpdateFairRequest;
+import com.bamdoliro.maru.presentation.fair.dto.request.*;
 import com.bamdoliro.maru.shared.fixture.AuthFixture;
 import com.bamdoliro.maru.shared.fixture.FairFixture;
 import com.bamdoliro.maru.shared.fixture.UserFixture;
@@ -20,6 +17,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.payload.JsonFieldType;
+
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
@@ -426,15 +425,20 @@ class FairControllerTest extends RestDocsTestSupport {
         Long attendeeId = 1L;
         User user = UserFixture.createAdminUser();
 
+        DeleteAttendeeRequest deleteAttendeeRequest = new DeleteAttendeeRequest(attendeeId);
+        DeleteAttendeeListRequest request = new DeleteAttendeeListRequest(List.of(deleteAttendeeRequest));
+
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        willDoNothing().given(deleteAttendeeUseCase).execute(fairId, attendeeId);
+        willDoNothing().given(deleteAttendeeUseCase).execute(eq(fairId), any(DeleteAttendeeListRequest.class));
 
-        mockMvc.perform(delete("/fairs/{fair-id}/attendees/{attendee-id}", fairId, attendeeId)
+        mockMvc.perform(delete("/fairs/{fair-id}/attendees", fairId)
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
-                        .accept(MediaType.APPLICATION_JSON))
+                        .accept(MediaType.APPLICATION_JSON)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(request)))
 
-                .andExpect(status().isOk())
+                .andExpect(status().isNoContent())
 
                 .andDo(restDocs.document(
                         requestHeaders(
@@ -443,33 +447,18 @@ class FairControllerTest extends RestDocsTestSupport {
                         ),
                         pathParameters(
                                 parameterWithName("fair-id")
-                                        .description("입학설명회 id"),
-                                parameterWithName("attendee-id")
+                                        .description("입학설명회 id")
+                        ),
+                        requestFields(
+                                fieldWithPath("attendeeList")
+                                        .type(JsonFieldType.ARRAY)
+                                        .description("삭제할 신청자 목록"),
+                                fieldWithPath("attendeeList[].attendeeId")
+                                        .type(JsonFieldType.NUMBER)
                                         .description("신청자 id")
                         )
                 ));
 
-        verify(deleteAttendeeUseCase, times(1)).execute(fairId, attendeeId);
-    }
-
-    @Test
-    void 입학설명회_신청자를_삭제할_때_신청자가_없으면_에러가_발생한다() throws Exception {
-        Long fairId = 1L;
-        Long attendeeId = -1L;
-        User user = UserFixture.createAdminUser();
-
-        given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
-        given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        willThrow(new AttendeeNotFoundException()).given(deleteAttendeeUseCase).execute(fairId, attendeeId);
-
-        mockMvc.perform(delete("/fairs/{fair-id}/attendees/{attendee-id}", fairId, attendeeId)
-                        .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
-                        .accept(MediaType.APPLICATION_JSON))
-
-                .andExpect(status().isNotFound())
-
-                .andDo(restDocs.document());
-
-        verify(deleteAttendeeUseCase, times(1)).execute(fairId, attendeeId);
+        verify(deleteAttendeeUseCase, times(1)).execute(eq(fairId), any(DeleteAttendeeListRequest.class));
     }
 }


### PR DESCRIPTION
## 🎫 관련 이슈

close #123

<br>

## 📄 개요

> 입학설명회 신청자 삭제 방식을 수정했습니다.

<br>

## 🔨 작업 내용

- 입학설명회 신청자 삭제 방식을 일괄 처리가 되도록 수정했습니다.


<br>

## 🏁 확인 사항
- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말