### PR TITLE
[새기능] 입학설명회 신청자 정렬

### DIFF
--- a/src/docs/asciidoc/fair.adoc
+++ b/src/docs/asciidoc/fair.adoc
@@ -118,6 +118,9 @@ include::{snippets}/fair-controller-test/입학설명회를_상세히_불러온�
 ===== Path Parameter
 include::{snippets}/fair-controller-test/입학설명회를_상세히_불러온다/path-parameters.adoc[]
 
+===== Query Parameter
+include::{snippets}/fair-controller-test/입학설명회를_상세히_불러온다/query-parameters.adoc[]
+
 ===== 요청
 include::{snippets}/fair-controller-test/입학설명회를_상세히_불러온다/http-request.adoc[]
 

--- a/src/main/java/com/bamdoliro/maru/application/fair/QueryFairDetailUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/fair/QueryFairDetailUseCase.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @UseCase
@@ -23,11 +22,11 @@ public class QueryFairDetailUseCase {
 
         List<Attendee> sortedAttendeeList = switch (sort) {
             case "name_asc" -> fair.getAttendeeList().stream()
-                .sorted(Comparator.comparing(Attendee::getName))
-                .collect(Collectors.toList());
+                    .sorted(Comparator.comparing(Attendee::getName))
+                    .toList();
             case "name_desc" -> fair.getAttendeeList().stream()
-                .sorted(Comparator.comparing(Attendee::getName).reversed())
-                .collect(Collectors.toList());
+                    .sorted(Comparator.comparing(Attendee::getName).reversed())
+                    .toList();
             default -> fair.getAttendeeList();
         };
 

--- a/src/main/java/com/bamdoliro/maru/application/fair/QueryFairDetailUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/fair/QueryFairDetailUseCase.java
@@ -1,10 +1,15 @@
 package com.bamdoliro.maru.application.fair;
 
+import com.bamdoliro.maru.domain.fair.domain.Attendee;
 import com.bamdoliro.maru.domain.fair.domain.Fair;
 import com.bamdoliro.maru.infrastructure.persistence.fair.AttendeeRepository;
 import com.bamdoliro.maru.presentation.fair.dto.response.FairDetailResponse;
 import com.bamdoliro.maru.shared.annotation.UseCase;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @UseCase
@@ -13,8 +18,19 @@ public class QueryFairDetailUseCase {
     private final FairFacade fairFacade;
     private final AttendeeRepository attendeeRepository;
 
-    public FairDetailResponse execute(Long fairId) {
+    public FairDetailResponse execute(Long fairId, String sort) {
         Fair fair = fairFacade.getFairDetail(fairId);
-        return new FairDetailResponse(fair, attendeeRepository);
+
+        List<Attendee> sortedAttendeeList = switch (sort) {
+            case "name_asc" -> fair.getAttendeeList().stream()
+                .sorted(Comparator.comparing(Attendee::getName))
+                .collect(Collectors.toList());
+            case "name_desc" -> fair.getAttendeeList().stream()
+                .sorted(Comparator.comparing(Attendee::getName).reversed())
+                .collect(Collectors.toList());
+            default -> fair.getAttendeeList();
+        };
+
+        return new FairDetailResponse(fair, sortedAttendeeList, attendeeRepository);
     }
 }

--- a/src/main/java/com/bamdoliro/maru/presentation/fair/FairController.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/fair/FairController.java
@@ -87,10 +87,11 @@ public class FairController {
     @GetMapping("/{fair-id}")
     public SingleCommonResponse<FairDetailResponse> getFairDetail(
             @AuthenticationPrincipal(authority = Authority.ADMIN) User user,
-            @PathVariable(name = "fair-id") Long fairId
+            @PathVariable(name = "fair-id") Long fairId,
+            @RequestParam(name = "sort", required = false, defaultValue = "none") String sort
     ) {
         return CommonResponse.ok(
-                queryFairDetailUseCase.execute(fairId)
+                queryFairDetailUseCase.execute(fairId, sort)
         );
     }
 

--- a/src/main/java/com/bamdoliro/maru/presentation/fair/dto/response/FairDetailResponse.java
+++ b/src/main/java/com/bamdoliro/maru/presentation/fair/dto/response/FairDetailResponse.java
@@ -1,5 +1,6 @@
 package com.bamdoliro.maru.presentation.fair.dto.response;
 
+import com.bamdoliro.maru.domain.fair.domain.Attendee;
 import com.bamdoliro.maru.domain.fair.domain.Fair;
 import com.bamdoliro.maru.domain.fair.domain.type.FairStatus;
 import com.bamdoliro.maru.domain.fair.domain.type.FairType;
@@ -25,7 +26,7 @@ public class FairDetailResponse {
     private FairStatus status;
     private List<AttendeeResponse> attendeeList;
 
-    public FairDetailResponse(Fair fair, AttendeeRepository attendeeRepository) {
+    public FairDetailResponse(Fair fair, List<Attendee> sortedAttendeeList, AttendeeRepository attendeeRepository) {
         this.start = fair.getStart();
         this.place = fair.getPlace();
         this.capacity = fair.getCapacity();
@@ -33,7 +34,7 @@ public class FairDetailResponse {
         this.applicationStartDate = fair.getApplicationStartDate();
         this.applicationEndDate = fair.getApplicationEndDate();
         this.status = fair.getStatus(attendeeRepository);
-        this.attendeeList = fair.getAttendeeList().stream()
+        this.attendeeList = sortedAttendeeList.stream()
                 .map(AttendeeResponse::new)
                 .collect(Collectors.toList());
     }

--- a/src/test/java/com/bamdoliro/maru/application/fair/QueryFairDetailUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/fair/QueryFairDetailUseCaseTest.java
@@ -17,9 +17,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class QueryFairDetailUseCaseTest {
@@ -40,7 +38,41 @@ class QueryFairDetailUseCaseTest {
         given(fairFacade.getFairDetail(fair.getId())).willReturn(fair);
 
         // when
-        FairDetailResponse response = queryFairDetailUseCase.execute(fair.getId());
+        FairDetailResponse response = queryFairDetailUseCase.execute(fair.getId(), "none");
+
+        // then
+        assertEquals(fair.getStart(), response.getStart());
+        assertEquals(fair.getPlace(), response.getPlace());
+        assertEquals(fair.getAttendeeList().size(), response.getAttendeeList().size());
+
+        verify(fairFacade, times(1)).getFairDetail(fair.getId());
+    }
+
+    @Test
+    void 입학설명회를_상세히_불러올_때_이름_오름차순으로_정렬한다() {
+        // given
+        Fair fair = FairFixture.createFairDetail();
+        given(fairFacade.getFairDetail(fair.getId())).willReturn(fair);
+
+        // when
+        FairDetailResponse response = queryFairDetailUseCase.execute(fair.getId(), "name_asc");
+
+        // then
+        assertEquals(fair.getStart(), response.getStart());
+        assertEquals(fair.getPlace(), response.getPlace());
+        assertEquals(fair.getAttendeeList().size(), response.getAttendeeList().size());
+
+        verify(fairFacade, times(1)).getFairDetail(fair.getId());
+    }
+
+    @Test
+    void 입학설명회를_상세히_불러올_때_이름_내림차순으로_정렬한다() {
+        // given
+        Fair fair = FairFixture.createFairDetail();
+        given(fairFacade.getFairDetail(fair.getId())).willReturn(fair);
+
+        // when
+        FairDetailResponse response = queryFairDetailUseCase.execute(fair.getId(), "name_desc");
 
         // then
         assertEquals(fair.getStart(), response.getStart());
@@ -57,7 +89,7 @@ class QueryFairDetailUseCaseTest {
 
         // when and then
         assertThrows(FairNotFoundException.class,
-                () -> queryFairDetailUseCase.execute(-1L));
+                () -> queryFairDetailUseCase.execute(-1L, "none"));
 
         verify(fairFacade, times(1)).getFairDetail(anyLong());
         verify(attendeeRepository, never()).countByFair(any(Fair.class));

--- a/src/test/java/com/bamdoliro/maru/presentation/fair/FairControllerTest.java
+++ b/src/test/java/com/bamdoliro/maru/presentation/fair/FairControllerTest.java
@@ -321,7 +321,7 @@ class FairControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        given(queryFairDetailUseCase.execute(fairId)).willReturn(FairFixture.createFairDetailResponse());
+        given(queryFairDetailUseCase.execute(fairId, "none")).willReturn(FairFixture.createFairDetailResponse());
 
         mockMvc.perform(get("/fairs/{fair-id}", fairId)
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
@@ -338,10 +338,55 @@ class FairControllerTest extends RestDocsTestSupport {
                         pathParameters(
                                 parameterWithName("fair-id")
                                         .description("입학설명회 id")
+                        ),
+                        queryParameters(
+                                parameterWithName("sort")
+                                        .optional()
+                                        .description("정렬 방식 (none, name_asc, name_desc)")
                         )
                 ));
 
-        verify(queryFairDetailUseCase, times(1)).execute(fairId);
+        verify(queryFairDetailUseCase, times(1)).execute(fairId, "none");
+    }
+
+    @Test
+    void 입학설명회를_상세히_불러올_때_이름_오름차순으로_정렬한다() throws Exception {
+        Long fairId = 1L;
+        User user = UserFixture.createAdminUser();
+
+        given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
+        given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
+        given(queryFairDetailUseCase.execute(fairId, "name_asc")).willReturn(FairFixture.createFairDetailResponse());
+
+        mockMvc.perform(get("/fairs/{fair-id}", fairId)
+                        .param("sort", "name_asc")
+                        .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
+                        .accept(MediaType.APPLICATION_JSON)
+                )
+
+                .andExpect(status().isOk());
+
+        verify(queryFairDetailUseCase, times(1)).execute(fairId, "name_asc");
+    }
+
+    @Test
+    void 입학설명회를_상세히_불러올_때_이름_내림차순으로_정렬한다() throws Exception {
+        Long fairId = 1L;
+        User user = UserFixture.createAdminUser();
+
+        given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
+        given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
+        given(queryFairDetailUseCase.execute(fairId, "name_desc")).willReturn(FairFixture.createFairDetailResponse());
+
+        mockMvc.perform(get("/fairs/{fair-id}", fairId)
+                        .param("sort", "name_desc")
+                        .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
+                        .accept(MediaType.APPLICATION_JSON)
+                )
+
+                .andExpect(status().isOk());
+
+        verify(queryFairDetailUseCase, times(1)).execute(fairId, "name_desc");
     }
 
     @Test
@@ -351,7 +396,7 @@ class FairControllerTest extends RestDocsTestSupport {
 
         given(authenticationArgumentResolver.supportsParameter(any(MethodParameter.class))).willReturn(true);
         given(authenticationArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(user);
-        willThrow(new FairNotFoundException()).given(queryFairDetailUseCase).execute(fairId);
+        willThrow(new FairNotFoundException()).given(queryFairDetailUseCase).execute(fairId, "none");
 
         mockMvc.perform(get("/fairs/{fair-id}", fairId)
                         .header(HttpHeaders.AUTHORIZATION, AuthFixture.createAuthHeader())
@@ -362,7 +407,7 @@ class FairControllerTest extends RestDocsTestSupport {
 
                 .andDo(restDocs.document());
 
-        verify(queryFairDetailUseCase, times(1)).execute(fairId);
+        verify(queryFairDetailUseCase, times(1)).execute(fairId, "none");
     }
 
     @Test

--- a/src/test/java/com/bamdoliro/maru/shared/fixture/FairFixture.java
+++ b/src/test/java/com/bamdoliro/maru/shared/fixture/FairFixture.java
@@ -127,6 +127,7 @@ public class FairFixture {
     }
 
     public static FairDetailResponse createFairDetailResponse() {
-        return new FairDetailResponse(createFairDetail(), null);
+        Fair fair = createFairDetail();
+        return new FairDetailResponse(fair, fair.getAttendeeList(), null);
     }
 }


### PR DESCRIPTION
## 🎫 관련 이슈

close #133

<br>

## 📄 개요

> 입학설명회 신청자 정렬 추가

<br>

## 🔨 작업 내용

- 입학설명회 신청자 이름별 오름차, 내림차 정렬 기능을 추가했습니다.


<br>

## 🏁 확인 사항
- [x] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말