### PR TITLE
[버그] 반려된 원서 수정시 반영 안되는 버그

### DIFF
--- a/src/main/java/com/bamdoliro/maru/application/form/UpdateFormUseCase.java
+++ b/src/main/java/com/bamdoliro/maru/application/form/UpdateFormUseCase.java
@@ -5,6 +5,7 @@ import com.bamdoliro.maru.domain.form.exception.CannotUpdateNotRejectedFormExcep
 import com.bamdoliro.maru.domain.form.service.CalculateFormScoreService;
 import com.bamdoliro.maru.domain.form.service.FormFacade;
 import com.bamdoliro.maru.domain.user.domain.User;
+import com.bamdoliro.maru.infrastructure.persistence.form.FormRepository;
 import com.bamdoliro.maru.presentation.form.dto.request.UpdateFormRequest;
 import com.bamdoliro.maru.shared.annotation.UseCase;
 import com.bamdoliro.maru.shared.annotation.ValidateApplicationFormPeriod;
@@ -17,6 +18,7 @@ public class UpdateFormUseCase {
 
     private final FormFacade formFacade;
     private final CalculateFormScoreService calculateFormScoreService;
+    private final FormRepository formRepository;
 
     @ValidateApplicationFormPeriod
     @Transactional
@@ -35,6 +37,7 @@ public class UpdateFormUseCase {
         );
 
         calculateFormScoreService.execute(form);
+        formRepository.save(form);
 
     }
 

--- a/src/test/java/com/bamdoliro/maru/application/form/UpdateFormUseCaseTest.java
+++ b/src/test/java/com/bamdoliro/maru/application/form/UpdateFormUseCaseTest.java
@@ -8,6 +8,7 @@ import com.bamdoliro.maru.domain.form.exception.FormNotFoundException;
 import com.bamdoliro.maru.domain.form.service.CalculateFormScoreService;
 import com.bamdoliro.maru.domain.form.service.FormFacade;
 import com.bamdoliro.maru.domain.user.domain.User;
+import com.bamdoliro.maru.infrastructure.persistence.form.FormRepository;
 import com.bamdoliro.maru.shared.fixture.FormFixture;
 import com.bamdoliro.maru.shared.fixture.UserFixture;
 import org.junit.jupiter.api.Test;
@@ -34,6 +35,9 @@ class UpdateFormUseCaseTest {
 
     @Mock
     private CalculateFormScoreService calculateFormScoreService;
+
+    @Mock
+    private FormRepository formRepository;
 
     @Test
     void 원서를_수정한다() {


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #148 

<br>

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)

> 반려된 원서의 성적을 바꾸어 입력해도 점수가 바뀌지 않는 문제를 해결하였습니다.

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)

- UpdateFormUseCase에  Calculater 와 FormRepository를 추가하여 각각 점수 계산후 저장하도록 하였습니다.


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [ ] 테스트를 완료했나요?
- [x] API 문서를 작성했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)